### PR TITLE
Add support for codec switching using SourceBuffer.changeType()

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,8 +980,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       "publisher": "W3C"
     }
   },
-  "publishISODate": "2018-05-29T00:00:00.000Z",
-  "generatedSubtitle": "Editor's Draft 29 May 2018"
+  "publishISODate": "2018-05-30T00:00:00.000Z",
+  "generatedSubtitle": "Editor's Draft 30 May 2018"
 }</script><meta name="description" content="This specification extends HTMLMediaElement [HTML51] to allow
       JavaScript to generate media streams for playback.
       Allowing JavaScript to generate streams facilitates a variety of use
@@ -992,7 +992,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </a>
   <h1 id="title" class="title p-name">Media Source Extensions™ - Codec Switching feature incubation</h1>
   
-  <h2 id="w3c-editor-s-draft-29-may-2018"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time class="dt-published" datetime="2018-05-29">29 May 2018</time></h2>
+  <h2 id="w3c-editor-s-draft-30-may-2018"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time class="dt-published" datetime="2018-05-30">30 May 2018</time></h2>
   <dl>
     <dt>This version:</dt><dd><a class="u-url" href="https://w3c.github.io/media-source/">https://w3c.github.io/media-source/</a></dd><dt>Latest published version:</dt><dd><a href="https://www.w3.org/TR/media-source/">https://www.w3.org/TR/media-source/</a></dd>
     <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/media-source/">https://w3c.github.io/media-source/</a></dd>
@@ -2420,6 +2420,10 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                         then the user agent <em class="rfc2119" title="MAY">MAY</em> use this step to trigger a decode error even if the other two properties'
                         checks, above, pass. Implementations are encouraged to trigger error in such cases only when the codec
                         is indeed not supported or the other two properties' checks fail.
+                        Web authors are encouraged to use <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code>, <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> and
+                        <code><a href="#dom-mediasource-istypesupported">isTypeSupported()</a></code> with precise codec parameters to more proactively detect user agent
+                        support. <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> is required if the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object's bytestream format
+                        is changing.
                       </p></div>
                     </li>
                   </ul>
@@ -2442,6 +2446,10 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                     <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> was called with 'video/webm;codecs="vp8"' and a Vorbis track appears in the
                     <a href="#init-segment">initialization segment</a>, then the user agent <em class="rfc2119" title="MAY">MAY</em> use this step to trigger a decode error.
                     Implementations are encouraged to trigger error in such cases only when the codec is indeed not supported.
+                    Web authors are encouraged to use <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code>, <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> and
+                    <code><a href="#dom-mediasource-istypesupported">isTypeSupported()</a></code> with precise codec parameters to more proactively detect user agent
+                    support. <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> is required if the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object's bytestream format
+                    is changing.
                   </p></div>
                 </li>
                 <li>
@@ -2994,7 +3002,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
           </ol>
           <div class="note" id="issue-container-generatedID-70"><div role="heading" class="note-title marker" id="h-note-70" aria-level="5"><span>Note</span></div><div class="">
             <p>Here is a graphical representation of this algorithm.</p>
-            <img src="audio_splice.png" alt="Audio splice diagram" height="0" width="0">
+            <img src="audio_splice.png" alt="Audio splice diagram" height="225" width="360">
           </div></div>
         </section>
         <section id="sourcebuffer-text-splice-frame-algorithm">

--- a/index.html
+++ b/index.html
@@ -1,919 +1,865 @@
-<!DOCTYPE html>
-<html lang="en" dir="ltr" typeof="bibo:Document " prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta lang="" property="dc:language" content="en">
-  <style>
-    /*
+<!DOCTYPE html><html lang="en" dir="ltr"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><meta name="generator" content="ReSpec 21.0.1"><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><style>/* --- ISSUES/NOTES --- */
+div.issue-title, div.note-title , div.ednote-title, div.warning-title {
+    padding-right:  1em;
+    min-width: 7.5em;
+    color: #b9ab2d;
+}
+div.issue-title { color: #e05252; }
+div.note-title, div.ednote-title { color: #2b2; }
+div.warning-title { color: #f22; }
+div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
+    text-transform: uppercase;
+}
+div.note, div.issue, div.ednote, div.warning {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
+.issue, .note, .ednote, .warning {
+    padding: .5em;
+    border-left-width: .5em;
+    border-left-style: solid;
+}
+div.issue, div.note , div.ednote,  div.warning {
+    padding: 1em 1.2em 0.5em;
+    margin: 1em 0;
+    position: relative;
+    clear: both;
+}
+span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
 
-github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+.issue {
+    border-color: #e05252;
+    background: #fbe9e9;
+}
+.note, .ednote {
+    border-color: #52e052;
+    background: #e9fbe9;
+}
 
-*/
-    
-    .hljs {
-      display: block;
-      overflow-x: auto;
-      padding: 0.5em;
-      color: #333;
-      background: #f8f8f8;
-    }
-    
-    .hljs-comment,
-    .hljs-quote {
-      color: #998;
-      font-style: italic;
-    }
-    
-    .hljs-keyword,
-    .hljs-selector-tag,
-    .hljs-subst {
-      color: #333;
-      font-weight: bold;
-    }
-    
-    .hljs-number,
-    .hljs-literal,
-    .hljs-variable,
-    .hljs-template-variable,
-    .hljs-tag .hljs-attr {
-      color: #008080;
-    }
-    
-    .hljs-string,
-    .hljs-doctag {
-      color: #d14;
-    }
-    
-    .hljs-title,
-    .hljs-section,
-    .hljs-selector-id {
-      color: #900;
-      font-weight: bold;
-    }
-    
-    .hljs-subst {
-      font-weight: normal;
-    }
-    
-    .hljs-type,
-    .hljs-class .hljs-title {
-      color: #458;
-      font-weight: bold;
-    }
-    
-    .hljs-tag,
-    .hljs-name,
-    .hljs-attribute {
-      color: #000080;
-      font-weight: normal;
-    }
-    
-    .hljs-regexp,
-    .hljs-link {
-      color: #009926;
-    }
-    
-    .hljs-symbol,
-    .hljs-bullet {
-      color: #990073;
-    }
-    
-    .hljs-built_in,
-    .hljs-builtin-name {
-      color: #0086b3;
-    }
-    
-    .hljs-meta {
-      color: #999;
-      font-weight: bold;
-    }
-    
-    .hljs-deletion {
-      background: #fdd;
-    }
-    
-    .hljs-addition {
-      background: #dfd;
-    }
-    
-    .hljs-emphasis {
-      font-style: italic;
-    }
-    
-    .hljs-strong {
-      font-weight: bold;
-    }
-  </style>
-  <style>
-    /* --- ISSUES/NOTES --- */
-    
-    div.issue-title,
-    div.note-title,
-    div.ednote-title,
-    div.warning-title {
-      padding-right: 1em;
-      min-width: 7.5em;
-      color: #b9ab2d;
-    }
-    
-    div.issue-title {
-      color: #e05252;
-    }
-    
-    div.note-title,
-    div.ednote-title {
-      color: #2b2;
-    }
-    
-    div.warning-title {
-      color: #f22;
-    }
-    
-    div.issue-title span,
-    div.note-title span,
-    div.ednote-title span,
-    div.warning-title span {
-      text-transform: uppercase;
-    }
-    
-    div.note,
-    div.issue,
-    div.ednote,
-    div.warning {
-      margin-top: 1em;
-      margin-bottom: 1em;
-    }
-    
-    .note>p:first-child,
-    .ednote>p:first-child,
-    .issue>p:first-child,
-    .warning>p:first-child {
-      margin-top: 0
-    }
-    
-    .issue,
-    .note,
-    .ednote,
-    .warning {
-      padding: .5em;
-      border-left-width: .5em;
-      border-left-style: solid;
-    }
-    
-    div.issue,
-    div.note,
-    div.ednote,
-    div.warning {
-      padding: 1em 1.2em 0.5em;
-      margin: 1em 0;
-      position: relative;
-      clear: both;
-    }
-    
-    span.note,
-    span.ednote,
-    span.issue,
-    span.warning {
-      padding: .1em .5em .15em;
-    }
-    
-    .issue {
-      border-color: #e05252;
-      background: #fbe9e9;
-    }
-    
-    .note,
-    .ednote {
-      border-color: #52e052;
-      background: #e9fbe9;
-    }
-    
-    .warning {
-      border-color: #f11;
-      border-width: .2em;
-      border-style: solid;
-      background: #fbe9e9;
-    }
-    
-    .warning-title:before {
-      content: "⚠";
-      /*U+26A0 WARNING SIGN*/
-      font-size: 3em;
-      float: left;
-      height: 100%;
-      padding-right: .3em;
-      vertical-align: top;
-      margin-top: -0.5em;
-    }
-    
-    li.task-list-item {
-      list-style: none;
-    }
-    
-    input.task-list-item-checkbox {
-      margin: 0 0.35em 0.25em -1.6em;
-      vertical-align: middle;
-    }
-  </style>
-  <style>
-    /* --- WEB IDL --- */
-    
-    pre.idl {
-      border-top: 1px solid #90b8de;
-      border-bottom: 1px solid #90b8de;
-      padding: 1em;
-      line-height: 120%;
-    }
-    
-    @media print {
-      pre.idl {
-        white-space: pre-wrap;
-      }
-    }
-    
-    pre.idl::before {
-      content: "WebIDL";
-      display: block;
-      width: 150px;
-      background: #90b8de;
-      color: #fff;
-      font-family: sans-serif;
-      padding: 3px;
-      font-weight: bold;
-      margin: -1em 0 1em -1em;
-    }
-    
-    .idlType {
-      color: #ff4500;
-      font-weight: bold;
-      text-decoration: none;
-    }
-    /*.idlModule*/
-    /*.idlModuleID*/
-    /*.idlInterface*/
-    
-    .idlInterfaceID,
-    .idlDictionaryID,
-    .idlCallbackID,
-    .idlEnumID {
-      font-weight: bold;
-      color: #005a9c;
-    }
-    
-    a.idlEnumItem {
-      color: #000;
-      border-bottom: 1px dotted #ccc;
-      text-decoration: none;
-    }
-    
-    .idlSuperclass {
-      font-style: italic;
-      color: #005a9c;
-    }
-    /*.idlAttribute*/
-    
-    .idlAttrType,
-    .idlFieldType,
-    .idlMemberType {
-      color: #005a9c;
-    }
-    
-    .idlAttrName,
-    .idlFieldName,
-    .idlMemberName {
-      color: #ff4500;
-    }
-    
-    .idlAttrName a,
-    .idlFieldName a,
-    .idlMemberName a {
-      color: #ff4500;
-      border-bottom: 1px dotted #ff4500;
-      text-decoration: none;
-    }
-    /*.idlMethod*/
-    
-    .idlMethType,
-    .idlCallbackType {
-      color: #005a9c;
-    }
-    
-    .idlMethName {
-      color: #ff4500;
-    }
-    
-    .idlMethName a {
-      color: #ff4500;
-      border-bottom: 1px dotted #ff4500;
-      text-decoration: none;
-    }
-    /*.idlCtor*/
-    
-    .idlCtorName {
-      color: #ff4500;
-    }
-    
-    .idlCtorName a {
-      color: #ff4500;
-      border-bottom: 1px dotted #ff4500;
-      text-decoration: none;
-    }
-    /*.idlParam*/
-    
-    .idlParamType {
-      color: #005a9c;
-    }
-    
-    .idlParamName,
-    .idlDefaultValue {
-      font-style: italic;
-    }
-    
-    .extAttr {
-      color: #666;
-    }
-    /*.idlSectionComment*/
-    
-    .idlSectionComment {
-      color: gray;
-    }
-    /*.idlIterable*/
-    
-    .idlIterableKeyType,
-    .idlIterableValueType {
-      color: #005a9c;
-    }
-    /*.idlMaplike*/
-    
-    .idlMaplikeKeyType,
-    .idlMaplikeValueType {
-      color: #005a9c;
-    }
-    /*.idlConst*/
-    
-    .idlConstType {
-      color: #005a9c;
-    }
-    
-    .idlConstName {
-      color: #ff4500;
-    }
-    
-    .idlConstName a {
-      color: #ff4500;
-      border-bottom: 1px dotted #ff4500;
-      text-decoration: none;
-    }
-    /*.idlException*/
-    
-    .idlExceptionID {
-      font-weight: bold;
-      color: #c00;
-    }
-    
-    .idlTypedefID,
-    .idlTypedefType {
-      color: #005a9c;
-    }
-    
-    .idlRaises,
-    .idlRaises a.idlType,
-    .idlRaises a.idlType code,
-    .excName a,
-    .excName a code {
-      color: #c00;
-      font-weight: normal;
-    }
-    
-    .excName a {
-      font-family: monospace;
-    }
-    
-    .idlRaises a.idlType,
-    .excName a.idlType {
-      border-bottom: 1px dotted #c00;
-    }
-    
-    .excGetSetTrue,
-    .excGetSetFalse,
-    .prmNullTrue,
-    .prmNullFalse,
-    .prmOptTrue,
-    .prmOptFalse {
-      width: 45px;
-      text-align: center;
-    }
-    
-    .excGetSetTrue,
-    .prmNullTrue,
-    .prmOptTrue {
-      color: #0c0;
-    }
-    
-    .excGetSetFalse,
-    .prmNullFalse,
-    .prmOptFalse {
-      color: #c00;
-    }
-    
-    .idlImplements a {
-      font-weight: bold;
-    }
-    
-    dl.attributes,
-    dl.methods,
-    dl.constants,
-    dl.constructors,
-    dl.fields,
-    dl.dictionary-members {
-      margin-left: 2em;
-    }
-    
-    .attributes dt,
-    .methods dt,
-    .constants dt,
-    .constructors dt,
-    .fields dt,
-    .dictionary-members dt {
-      font-weight: normal;
-    }
-    
-    .attributes dt code,
-    .methods dt code,
-    .constants dt code,
-    .constructors dt code,
-    .fields dt code,
-    .dictionary-members dt code {
-      font-weight: bold;
-      color: #000;
-      font-family: monospace;
-    }
-    
-    .attributes dt code,
-    .fields dt code,
-    .dictionary-members dt code {
-      background: #ffffd2;
-    }
-    
-    .attributes dt .idlAttrType code,
-    .fields dt .idlFieldType code,
-    .dictionary-members dt .idlMemberType code {
-      color: #005a9c;
-      background: transparent;
-      font-family: inherit;
-      font-weight: normal;
-      font-style: italic;
-    }
-    
-    .methods dt code {
-      background: #d9e6f8;
-    }
-    
-    .constants dt code {
-      background: #ddffd2;
-    }
-    
-    .constructors dt code {
-      background: #cfc;
-    }
-    
-    .attributes dd,
-    .methods dd,
-    .constants dd,
-    .constructors dd,
-    .fields dd,
-    .dictionary-members dd {
-      margin-bottom: 1em;
-    }
-    
-    table.parameters,
-    table.exceptions {
-      border-spacing: 0;
-      border-collapse: collapse;
-      margin: 0.5em 0;
-      width: 100%;
-    }
-    
-    table.parameters {
-      border-bottom: 1px solid #90b8de;
-    }
-    
-    table.exceptions {
-      border-bottom: 1px solid #deb890;
-    }
-    
-    .parameters th,
-    .exceptions th {
-      color: inherit;
-      padding: 3px 5px;
-      text-align: left;
-      font-weight: normal;
-    }
-    
-    .parameters th {
-      color: #fff;
-      background: #005a9c;
-    }
-    
-    .exceptions th {
-      background: #deb890;
-    }
-    
-    .parameters td,
-    .exceptions td {
-      padding: 3px 10px;
-      border-top: 1px solid #ddd;
-      vertical-align: top;
-    }
-    
-    .parameters tr:first-child td,
-    .exceptions tr:first-child td {
-      border-top: none;
-    }
-    
-    .parameters td.prmName,
-    .exceptions td.excName,
-    .exceptions td.excCodeName {
-      width: 100px;
-    }
-    
-    .parameters td.prmType {
-      width: 120px;
-    }
-    
-    table.exceptions table {
-      border-spacing: 0;
-      border-collapse: collapse;
-      width: 100%;
-    }
-  </style>
-  <style id="respec-mainstyle">
-    /*****************************************************************
- * ReSpec 3 CSS
- * Robin Berjon - http://berjon.com/
- *****************************************************************/
-    /* Override code highlighter background */
-    
-    .hljs {
-      background: transparent !important;
-    }
-    /* --- INLINES --- */
-    
-    em.rfc2119 {
-      text-transform: lowercase;
-      font-variant: small-caps;
-      font-style: normal;
-      color: #900;
-    }
-    
-    h1 acronym,
-    h2 acronym,
-    h3 acronym,
-    h4 acronym,
-    h5 acronym,
-    h6 acronym,
-    a acronym,
-    h1 abbr,
-    h2 abbr,
-    h3 abbr,
-    h4 abbr,
-    h5 abbr,
-    h6 abbr,
-    a abbr {
-      border: none;
-    }
-    
-    dfn {
-      font-weight: bold;
-    }
-    
-    a.internalDFN {
-      color: inherit;
-      border-bottom: 1px solid #99c;
-      text-decoration: none;
-    }
-    
-    a.externalDFN {
-      color: inherit;
-      border-bottom: 1px dotted #ccc;
-      text-decoration: none;
-    }
-    
-    a.bibref {
-      text-decoration: none;
-    }
-    
-    cite .bibref {
-      font-style: normal;
-    }
-    
-    code {
-      color: #C83500;
-    }
-    
-    th code {
-      color: inherit;
-    }
-    /* --- TOC --- */
-    
-    .toc a,
-    .tof a {
-      text-decoration: none;
-    }
-    
-    a .secno,
-    a .figno {
-      color: #000;
-    }
-    
-    ul.tof,
-    ol.tof {
-      list-style: none outside none;
-    }
-    
-    .caption {
-      margin-top: 0.5em;
-      font-style: italic;
-    }
-    /* --- TABLE --- */
-    
-    table.simple {
-      border-spacing: 0;
-      border-collapse: collapse;
-      border-bottom: 3px solid #005a9c;
-    }
-    
-    .simple th {
-      background: #005a9c;
-      color: #fff;
-      padding: 3px 5px;
-      text-align: left;
-    }
-    
-    .simple th[scope="row"] {
-      background: inherit;
-      color: inherit;
-      border-top: 1px solid #ddd;
-    }
-    
-    .simple td {
-      padding: 3px 10px;
-      border-top: 1px solid #ddd;
-    }
-    
-    .simple tr:nth-child(even) {
-      background: #f0f6ff;
-    }
-    /* --- DL --- */
-    
-    .section dd>p:first-child {
-      margin-top: 0;
-    }
-    
-    .section dd>p:last-child {
-      margin-bottom: 0;
-    }
-    
-    .section dd {
-      margin-bottom: 1em;
-    }
-    
-    .section dl.attrs dd,
-    .section dl.eldef dd {
-      margin-bottom: 0;
-    }
-    
-    .respec-hidden {
-      display: none;
-    }
-    
-    #respec-ui {
-      position: fixed;
-      top: 20px;
-      right: 20px;
-      width: 202px;
-      text-align: right;
-    }
-    
-    #respec-pill,
-    .respec-info-button {
-      background: #fff;
-      height: 2.5em;
-      color: rgb(120, 120, 120);
-      border: 1px solid #ccc;
-      box-shadow: 1px 1px 8px 0 rgba(100, 100, 100, .5);
-    }
-    
-    .respec-info-button {
-      border: none;
-      border-radius: 2em;
-      margin-right: 1em;
-      min-width: 3.5em;
-    }
-    
-    #respec-pill:disabled {
-      margin: 10px auto;
-      font-size: 2.8px;
-      position: relative;
-      text-indent: -9999em;
-      border-top: 1.1em solid rgba(40, 40, 40, 0.2);
-      border-right: 1.1em solid rgba(40, 40, 40, 0.2);
-      border-bottom: 1.1em solid rgba(40, 40, 40, 0.2);
-      border-left: 1.1em solid #ffffff;
-      transform: translateZ(0);
-      animation: respec-spin 1.1s infinite linear;
-      box-shadow: none;
-    }
-    
-    #respec-pill:disabled,
-    #respec-pill:disabled:after {
-      border-radius: 50%;
-      width: 10em;
-      height: 10em;
-    }
-    
-    @keyframes respec-spin {
-      0% {
-        transform: rotate(0deg);
-      }
-      100% {
-        transform: rotate(360deg);
-      }
-    }
-    
-    #respec-pill:hover,
-    #respec-pill:focus {
-      color: rgb(0, 0, 0);
-      transition: color .2s
-    }
-    
-    #respec-menu {
-      font-family: sans-serif;
-      background: #fff;
-      box-shadow: 1px 1px 8px 0 rgba(100, 100, 100, .5);
-      width: 200px;
-      display: none;
-      text-align: left;
-      margin-top: 5px;
-      font-size: .8em;
-    }
-    
-    .respec-save-button {
-      background: #fff;
-      border: 1px solid #000;
-      border-radius: 5px;
-      padding: 5px;
-      margin: 5px;
-      display: block;
-      width: 100%;
-      color: #000;
-      text-decoration: none;
-      text-align: center;
-      font-size: inherit;
-    }
-    
-    #respec-ui button:focus,
-    #respec-pill:focus,
-    .respec-option:focus {
-      outline: 0;
-      outline-style: none;
-    }
-    
-    #respec-ui button.respec-pill-error {
-      background-color: red;
-      color: white;
-    }
-    
-    #respec-ui button.respec-pill-warning {
-      background-color: orange;
-      color: white;
-    }
-    
-    #respec-menu button.respec-option {
-      background: white;
-      border: none;
-      width: 100%;
-      text-align: left;
-      font-size: inherit;
-      padding: 1.2em 1.2em;
-    }
-    
-    #respec-menu button.respec-option:hover {
-      background-color: #eeeeee;
-    }
-    
-    .respec-cmd-icon {
-      padding-right: .5em;
-    }
-    
-    #respec-ui button.respec-option:last-child {
-      border: none;
-      border-radius: inherit;
-    }
-    
-    @media print {
-      .removeOnSave {
-        display: none;
-      }
-    }
-  </style>
-  <title>Media Source Extensions™</title>
+.warning {
+    border-color: #f11;
+    border-width: .2em;
+    border-style: solid;
+    background: #fbe9e9;
+}
 
-  <!--<script src="respec-w3c-common.js" class="remove"></script>-->
+.warning-title:before{
+    content: "⚠"; /*U+26A0 WARNING SIGN*/
+    font-size: 3em;
+    float: left;
+    height: 100%;
+    padding-right: .3em;
+    vertical-align: top;
+    margin-top: -0.5em;
+}
+
+li.task-list-item {
+    list-style: none;
+}
+
+input.task-list-item-checkbox {
+    margin: 0 0.35em 0.25em -1.6em;
+    vertical-align: middle;
+}
+
+.issue a.respec-gh-label {
+  padding: 5px;
+  margin: 0 2px 0 2px;
+  font-size: 10px;
+  text-transform: none;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 4px;
+  position: relative;
+  bottom: 2px;
+}
+
+.issue a.respec-label-dark {
+  color: #fff;
+  background-color: #000;
+}
+
+.issue a.respec-label-light {
+  color: #000;
+  background-color: #fff;
+}
+</style><style>/* --- WEB IDL --- */
+
+pre.idl {
+  padding: 1em;
+}
+
+.respec-idl-separator {
+  padding: 0 0 0.4cm 0;
+}
+
+.respec-idl-separator:last-child {
+  padding: 0;
+}
+
+@media print {
+  pre.idl {
+    white-space: pre-wrap;
+  }
+}
+
+pre.idl::before {
+  content: "WebIDL";
+  display: block;
+  width: 150px;
+  background: #90b8de;
+  color: #fff;
+  font-family: sans-serif;
+  font-weight: bold;
+  margin: -1em 0 1em -1em;
+  height: 28px;
+  line-height: 28px;  
+}
+
+.idlType {
+  color: #ff4500;
+  font-weight: bold;
+  text-decoration: none;
+}
 
 
+/*.idlModule*/
 
-  <!-- script to register bugs -->
-  <!-- Disabled unless/until it supports GitHub issues.
+
+/*.idlModuleID*/
+
+
+/*.idlInterface*/
+
+.idlInterfaceID,
+.idlDictionaryID,
+.idlCallbackID,
+.idlEnumID {
+  font-weight: bold;
+  color: #005a9c;
+}
+
+a.idlEnumItem {
+  color: #000;
+  border-bottom: 1px dotted #ccc;
+  text-decoration: none;
+}
+
+.idlSuperclass {
+  font-style: italic;
+  color: #005a9c;
+}
+
+
+/*.idlAttribute*/
+
+.idlAttrType,
+.idlFieldType,
+.idlMemberType {
+  color: #005a9c;
+}
+
+.idlAttrName,
+.idlFieldName,
+.idlMemberName {
+  color: #ff4500;
+}
+
+.idlAttrName a,
+.idlFieldName a,
+.idlMemberName a {
+  color: #ff4500;
+  border-bottom: 1px dotted #ff4500;
+  text-decoration: none;
+}
+
+
+/*.idlMethod*/
+
+.idlMethType,
+.idlCallbackType {
+  color: #005a9c;
+}
+
+.idlMethName {
+  color: #ff4500;
+}
+
+.idlMethName a {
+  color: #ff4500;
+  border-bottom: 1px dotted #ff4500;
+  text-decoration: none;
+}
+
+
+/*.idlCtor*/
+
+.idlCtorName {
+  color: #ff4500;
+}
+
+.idlCtorName a {
+  color: #ff4500;
+  border-bottom: 1px dotted #ff4500;
+  text-decoration: none;
+}
+
+
+/*.idlParam*/
+
+.idlParamType {
+  color: #005a9c;
+}
+
+.idlParamName,
+.idlDefaultValue {
+  font-style: italic;
+}
+
+.extAttr {
+  color: #666;
+}
+
+
+/*.idlSectionComment*/
+
+.idlSectionComment {
+  color: gray;
+}
+
+
+/*.idlIterable*/
+
+.idlIterableKeyType,
+.idlIterableValueType {
+  color: #005a9c;
+}
+
+
+/*.idlMaplike*/
+
+.idlMaplikeKeyType,
+.idlMaplikeValueType {
+  color: #005a9c;
+}
+
+
+/*.idlConst*/
+
+.idlConstType {
+  color: #005a9c;
+}
+
+.idlConstName {
+  color: #ff4500;
+}
+
+.idlConstName a {
+  color: #ff4500;
+  border-bottom: 1px dotted #ff4500;
+  text-decoration: none;
+}
+
+
+/*.idlException*/
+
+.idlExceptionID {
+  font-weight: bold;
+  color: #c00;
+}
+
+.idlTypedefID,
+.idlTypedefType {
+  color: #005a9c;
+}
+
+.idlRaises,
+.idlRaises a.idlType,
+.idlRaises a.idlType code,
+.excName a,
+.excName a code {
+  color: #c00;
+  font-weight: normal;
+}
+
+.excName a {
+  font-family: monospace;
+}
+
+.idlRaises a.idlType,
+.excName a.idlType {
+  border-bottom: 1px dotted #c00;
+}
+
+.excGetSetTrue,
+.excGetSetFalse,
+.prmNullTrue,
+.prmNullFalse,
+.prmOptTrue,
+.prmOptFalse {
+  width: 45px;
+  text-align: center;
+}
+
+.excGetSetTrue,
+.prmNullTrue,
+.prmOptTrue {
+  color: #0c0;
+}
+
+.excGetSetFalse,
+.prmNullFalse,
+.prmOptFalse {
+  color: #c00;
+}
+
+.idlImplements a, .idlIncludes a {
+  font-weight: bold;
+}
+
+dl.attributes,
+dl.methods,
+dl.constants,
+dl.constructors,
+dl.fields,
+dl.dictionary-members {
+  margin-left: 2em;
+}
+
+.attributes dt,
+.methods dt,
+.constants dt,
+.constructors dt,
+.fields dt,
+.dictionary-members dt {
+  font-weight: normal;
+}
+
+.attributes dt code,
+.methods dt code,
+.constants dt code,
+.constructors dt code,
+.fields dt code,
+.dictionary-members dt code {
+  font-weight: bold;
+  color: #000;
+  font-family: monospace;
+}
+
+.attributes dt code,
+.fields dt code,
+.dictionary-members dt code {
+  background: #ffffd2;
+}
+
+.attributes dt .idlAttrType code,
+.fields dt .idlFieldType code,
+.dictionary-members dt .idlMemberType code {
+  color: #005a9c;
+  background: transparent;
+  font-family: inherit;
+  font-weight: normal;
+  font-style: italic;
+}
+
+.methods dt code {
+  background: #d9e6f8;
+}
+
+.constants dt code {
+  background: #ddffd2;
+}
+
+.constructors dt code {
+  background: #cfc;
+}
+
+.attributes dd,
+.methods dd,
+.constants dd,
+.constructors dd,
+.fields dd,
+.dictionary-members dd {
+  margin-bottom: 1em;
+}
+
+table.parameters,
+table.exceptions {
+  border-spacing: 0;
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  width: 100%;
+}
+
+table.parameters {
+  border-bottom: 1px solid #90b8de;
+}
+
+table.exceptions {
+  border-bottom: 1px solid #deb890;
+}
+
+.parameters th,
+.exceptions th {
+  color: inherit;
+  padding: 3px 5px;
+  text-align: left;
+  font-weight: normal;
+}
+
+.parameters th {
+  color: #fff;
+  background: #005a9c;
+}
+
+.exceptions th {
+  background: #deb890;
+}
+
+.parameters td,
+.exceptions td {
+  padding: 3px 10px;
+  border-top: 1px solid #ddd;
+  vertical-align: top;
+}
+
+.parameters tr:first-child td,
+.exceptions tr:first-child td {
+  border-top: none;
+}
+
+.parameters td.prmName,
+.exceptions td.excName,
+.exceptions td.excCodeName {
+  width: 100px;
+}
+
+.parameters td.prmType {
+  width: 120px;
+}
+
+table.exceptions table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.respec-button-copy-paste:focus {
+  text-decoration: none;
+  border-color: #51a7e8;
+  outline: none;
+  box-shadow: 0 0 5px rgba(81, 167, 232, 0.5);
+}
+
+.respec-button-copy-paste:focus:hover,
+.respec-button-copy-paste.selected:focus {
+  border-color: #51a7e8;
+}
+
+.respec-button-copy-paste:hover,
+.respec-button-copy-paste:active,
+.respec-button-copy-paste.zeroclipboard-is-hover,
+.respec-button-copy-paste.zeroclipboard-is-active {
+  text-decoration: none;
+  background-color: #ddd;
+  background-image: linear-gradient(#eee, #ddd);
+  border-color: #ccc;
+}
+
+.respec-button-copy-paste:active,
+.respec-button-copy-paste.selected,
+.respec-button-copy-paste.zeroclipboard-is-active {
+  background-color: #dcdcdc;
+  background-image: none;
+  border-color: #b5b5b5;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15)
+}
+
+.respec-button-copy-paste.selected:hover {
+  background-color: #cfcfcf;
+}
+
+.respec-button-copy-paste:disabled,
+.respec-button-copy-paste:disabled:hover,
+.respec-button-copy-paste.disabled,
+.respec-button-copy-paste.disabled:hover {
+  color: rgba(102, 102, 102, 0.5);
+  cursor: default;
+  background-color: rgba(229, 229, 229, 0.5);
+  background-image: none;
+  border-color: rgba(197, 197, 197, 0.5);
+  box-shadow: none;
+}
+</style>
+    
+    <title>Media Source Extensions™ - Codec Switching feature incubation</title>
+    
+    <!--<script src="respec-w3c-common.js" class="remove"></script>-->
+    
+    
+
+    <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
     -->
 
-  <link rel="stylesheet" href="mse.css">
-  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED">
-  <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
-  <link rel="canonical" href="https://www.w3.org/TR/media-source/">
-  <meta name="generator" content="ReSpec 6.1.1">
-  <script id="initialUserConfig" type="application/json">
+    <link rel="stylesheet" href="mse.css">
+  <style id="respec-mainstyle">/*****************************************************************
+ * ReSpec 3 CSS
+ * Robin Berjon - http://berjon.com/
+ *****************************************************************/
+
+/* Override code highlighter background */
+.hljs {
+  background: transparent !important;
+}
+
+/* --- INLINES --- */
+h1 abbr,
+h2 abbr,
+h3 abbr,
+h4 abbr,
+h5 abbr,
+h6 abbr,
+a abbr {
+  border: none;
+}
+
+dfn {
+  font-weight: bold;
+}
+
+a.internalDFN {
+  color: inherit;
+  border-bottom: 1px solid #99c;
+  text-decoration: none;
+}
+
+a.externalDFN {
+  color: inherit;
+  border-bottom: 1px dotted #ccc;
+  text-decoration: none;
+}
+
+a.bibref {
+  text-decoration: none;
+}
+
+cite .bibref {
+  font-style: normal;
+}
+
+code {
+  color: #c83500;
+}
+
+th code {
+  color: inherit;
+}
+
+/* --- TOC --- */
+
+.toc a,
+.tof a {
+  text-decoration: none;
+}
+
+a .secno,
+a .figno {
+  color: #000;
+}
+
+ul.tof,
+ol.tof {
+  list-style: none outside none;
+}
+
+.caption {
+  margin-top: 0.5em;
+  font-style: italic;
+}
+
+/* --- TABLE --- */
+
+table.simple {
+  border-spacing: 0;
+  border-collapse: collapse;
+  border-bottom: 3px solid #005a9c;
+}
+
+.simple th {
+  background: #005a9c;
+  color: #fff;
+  padding: 3px 5px;
+  text-align: left;
+}
+
+.simple th[scope="row"] {
+  background: inherit;
+  color: inherit;
+  border-top: 1px solid #ddd;
+}
+
+.simple td {
+  padding: 3px 10px;
+  border-top: 1px solid #ddd;
+}
+
+.simple tr:nth-child(even) {
+  background: #f0f6ff;
+}
+
+/* --- DL --- */
+
+.section dd > p:first-child {
+  margin-top: 0;
+}
+
+.section dd > p:last-child {
+  margin-bottom: 0;
+}
+
+.section dd {
+  margin-bottom: 1em;
+}
+
+.section dl.attrs dd,
+.section dl.eldef dd {
+  margin-bottom: 0;
+}
+
+#issue-summary > ul,
+.respec-dfn-list {
+  column-count: 2;
+}
+
+#issue-summary li,
+.respec-dfn-list li {
+  list-style: none;
+}
+
+details.respec-tests-details {
+  margin-left: 1em;
+  display: inline-block;
+  vertical-align: top;
+}
+
+details.respec-tests-details > * {
+  padding-right: 2em;
+}
+
+details.respec-tests-details[open] {
+  z-index: 999999;
+  position: absolute;
+  border: thin solid #cad3e2;
+  border-radius: .3em;
+  background-color: white;
+  padding-bottom: .5em;
+}
+
+details.respec-tests-details[open] > summary {
+  border-bottom: thin solid #cad3e2;
+  padding-left: 1em;
+  margin-bottom: 1em;
+  line-height: 2em;
+}
+
+details.respec-tests-details > ul {
+  width: 100%;
+  margin-top: -0.3em;
+}
+
+details.respec-tests-details > li {
+  padding-left: 1em;
+}
+
+@media print {
+  .removeOnSave {
+    display: none;
+  }
+}
+</style><style>/*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #009926;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED"><link rel="canonical" href="https://www.w3.org/TR/media-source/"><script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "useExperimentalStyles": true,
+  "shortName": "media-source",
+  "edDraftURI": "https://w3c.github.io/media-source/",
+  "previousMaturity": "PR",
+  "previousPublishDate": "2016-10-04",
+  "errata": "https://w3c.github.io/media-source/mse-1-errata.html",
+  "editors": [
     {
-      "specStatus": "ED",
-      "useExperimentalStyles": true,
-      "shortName": "media-source",
-      "edDraftURI": "http://w3c.github.io/media-source/",
-      "previousMaturity": "PR",
-      "previousPublishDate": "2016-10-04",
-      "editors": [
-      {
-        "name": "Matthew Wolenetz",
-        "url": "",
-        "company": "Google Inc.",
-        "companyURL": "http://www.google.com/"
-      },
-      {
-        "name": "Jerry Smith",
-        "url": "",
-        "company": "Microsoft Corporation",
-        "companyURL": "http://www.microsoft.com/"
-      },
-      {
-        "name": "Mark Watson",
-        "url": "",
-        "company": "Netflix Inc.",
-        "companyURL": "http://www.netflix.com/"
-      },
-      {
-        "name": "Aaron Colwell (until April 2015)",
-        "url": "",
-        "company": "Google Inc.",
-        "companyURL": "http://www.google.com/"
-      },
-      {
-        "name": "Adrian Bateman (until April 2015)",
-        "url": "",
-        "company": "Microsoft Corporation",
-        "companyURL": "http://www.microsoft.com/"
-      }],
-      "mseDefGroupName": "media-source",
-      "mseContributors": [
-        "Bob Lund",
-        "Alex Giladi",
-        "Duncan Rowden",
-        "Mark Vickers",
-        "Glenn Adams",
-        "Frank Galligan",
-        "Steven Robertson",
-        "Matt Ward",
-        "David Dorwin",
-        "Kevin Streeter",
-        "Joe Steele",
-        "Michael Thornburgh",
-        "Philip Jägenstedt",
-        "John Simmons",
-        "Pierre Lemieux",
-        "Cyril Concolato",
-        "Ralph Giles",
-        "David Singer",
-        "Tatsuya Igarashi",
-        "Chris Poole",
-        "Jer Noble",
-        "Matthew Gregan"
-      ],
-      "wg": "HTML Media Extensions Working Group",
-      "wgURI": "https://www.w3.org/html/wg/",
-      "wgPublicList": "public-html-media",
-      "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",
-      "lcEnd": "2016-08-10",
-      "prEnd": "2016-11-01",
-      "implementationReportURI": "http://tidoust.github.io/media-source-testcoverage/",
-      "noIDLIn": true,
-      "scheme": "https",
-      "otherLinks": [
-      {
-        "key": "Repository",
-        "data": [
+      "name": "Matthew Wolenetz",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Jerry Smith",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    },
+    {
+      "name": "Mark Watson",
+      "url": "",
+      "company": "Netflix Inc.",
+      "companyURL": "http://www.netflix.com/"
+    },
+    {
+      "name": "Aaron Colwell (until April 2015)",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Adrian Bateman (until April 2015)",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    }
+  ],
+  "mseDefGroupName": "media-source",
+  "mseContributors": [
+    "Alex Giladi",
+    "Bob Lund",
+    "Chris Poole",
+    "Cyril Concolato",
+    "David Dorwin",
+    "David Singer",
+    "Duncan Rowden",
+    "Frank Galligan",
+    "Glenn Adams",
+    "Jer Noble",
+    "Joe Steele",
+    "John Simmons",
+    "Kevin Streeter",
+    "Mark Vickers",
+    "Matt Ward",
+    "Matthew Gregan",
+    "Michael Thornburgh",
+    "Philip Jägenstedt",
+    "Pierre Lemieux",
+    "Ralph Giles",
+    "Steven Robertson",
+    "Tatsuya Igarashi"
+  ],
+  "wg": "HTML Media Extensions Working Group",
+  "wgURI": "https://www.w3.org/html/wg/",
+  "wgPublicList": "public-html-media",
+  "license": "w3c-software-doc",
+  "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",
+  "lcEnd": "2016-08-10",
+  "prEnd": "2016-11-01",
+  "implementationReportURI": "http://tidoust.github.io/media-source-testcoverage/",
+  "noIDLIn": true,
+  "scheme": "https",
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "data": [
         {
           "value": "We are on GitHub",
           "href": "https://github.com/w3c/media-source/"
@@ -925,19 +871,21 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         {
           "value": "Commit history",
           "href": "https://github.com/w3c/media-source/commits/gh-pages/media-source-respec.html"
-        }]
-      },
-      {
-        "key": "Mailing list",
-        "data": [
+        }
+      ]
+    },
+    {
+      "key": "Mailing list",
+      "data": [
         {
           "value": "public-html-media@w3.org",
           "href": "https://lists.w3.org/Archives/Public/public-html-media/"
-        }]
-      },
-      {
-        "key": "Implementation",
-        "data": [
+        }
+      ]
+    },
+    {
+      "key": "Implementation",
+      "data": [
         {
           "value": "Can I use Media Source Extensions?",
           "href": "http://caniuse.com/#feat=mediasource"
@@ -949,553 +897,414 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         {
           "value": "Test Suite repository",
           "href": "https://github.com/w3c/web-platform-tests/tree/master/media-source"
-        }]
-      }],
-      "preProcess": [
-        null
-      ],
-      "postProcess": [
-        null
-      ],
-      "localBiblio":
-      {
-        "MSE-REGISTRY":
-        {
-          "title": "Media Source Extensions Byte Stream Format Registry",
-          "href": "byte-stream-format-registry.html",
-          "authors": [
-            "Matthew Wolenetz",
-            "Jerry Smith",
-            "Aaron Colwell"
-          ],
-          "publisher": "W3C"
-        },
-        "INBANDTRACKS":
-        {
-          "title": "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
-          "href": "https://dev.w3.org/html5/html-sourcing-inband-tracks/",
-          "authors": [
-            "Bob Lund",
-            "Silvia Pfeiffer"
-          ],
-          "publisher": "W3C"
-        },
-        "MEDIA-PLAYBACK-QUALITY":
-        {
-          "title": "Media Playback Quality",
-          "href": "https://wicg.github.io/media-playback-quality/",
-          "authors": [
-            "Mounir Lamouri"
-          ],
-          "publisher": "W3C"
         }
-      }
+      ]
     }
-  </script>
-</head>
-<body class="h-entry" role="document" id="respecDocument">
-  <div class="head" role="contentinfo" id="respecHeader">
-    <p>
-      <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+  ],
+  "preProcess": [
+    null
+  ],
+  "postProcess": [
+    null
+  ],
+  "localBiblio": {
+    "INBANDTRACKS": {
+      "title": "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
+      "href": "https://dev.w3.org/html5/html-sourcing-inband-tracks/",
+      "authors": [
+        "Bob Lund",
+        "Silvia Pfeiffer"
+      ],
+      "publisher": "W3C"
+    },
+    "MEDIA-PLAYBACK-QUALITY": {
+      "title": "Media Playback Quality",
+      "href": "https://wicg.github.io/media-playback-quality/",
+      "authors": [
+        "Mounir Lamouri"
+      ],
+      "publisher": "W3C"
+    },
+    "MSE-REGISTRY": {
+      "title": "Media Source Extensions™ Byte Stream Format Registry",
+      "href": "byte-stream-format-registry.html",
+      "authors": [
+        "Matthew Wolenetz",
+        "Jerry Smith",
+        "Aaron Colwell"
+      ],
+      "publisher": "W3C"
+    },
+    "MSE-FORMAT-WEBM": {
+      "title": "WebM Byte Stream Format",
+      "href": "webm-byte-stream-format.html",
+      "authors": [
+        "Matthew Wolenetz",
+        "Jerry Smith",
+        "Aaron Colwell"
+      ],
+      "publisher": "W3C"
+    },
+    "MSE-FORMAT-ISOBMFF": {
+      "title": "ISO BMFF Byte Stream Format",
+      "href": "isobmff-byte-stream-format.html",
+      "authors": [
+        "Matthew Wolenetz",
+        "Jerry Smith",
+        "Mark Watson",
+        "Aaron Colwell",
+        "Adrian Bateman"
+      ],
+      "publisher": "W3C"
+    },
+    "MSE-FORMAT-MP2T": {
+      "title": "MPEG-2 Transport Streams Byte Stream Format",
+      "href": "mp2t-byte-stream-format.html",
+      "authors": [
+        "Matthew Wolenetz",
+        "Jerry Smith",
+        "Mark Watson",
+        "Aaron Colwell",
+        "Adrian Bateman"
+      ],
+      "publisher": "W3C"
+    },
+    "MSE-FORMAT-MPEG-AUDIO": {
+      "title": "MPEG Audio Byte Stream Format",
+      "href": "mpeg-audio-byte-stream-format.html",
+      "authors": [
+        "Dale Curtis",
+        "Matthew Wolenetz",
+        "Aaron Colwell"
+      ],
+      "publisher": "W3C"
+    }
+  },
+  "publishISODate": "2018-05-29T00:00:00.000Z",
+  "generatedSubtitle": "Editor's Draft 29 May 2018"
+}</script><meta name="description" content="This specification extends HTMLMediaElement [HTML51] to allow
+      JavaScript to generate media streams for playback.
+      Allowing JavaScript to generate streams facilitates a variety of use
+      cases like adaptive streaming and time shifting live streams."></head>
+  <body class="h-entry"><div class="head">
+  <a href="https://www.w3.org/" class="logo">
+      <img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C">
+  </a>
+  <h1 id="title" class="title p-name">Media Source Extensions™ - Codec Switching feature incubation</h1>
+  
+  <h2 id="w3c-editor-s-draft-29-may-2018"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time class="dt-published" datetime="2018-05-29">29 May 2018</time></h2>
+  <dl>
+    <dt>This version:</dt><dd><a class="u-url" href="https://w3c.github.io/media-source/">https://w3c.github.io/media-source/</a></dd><dt>Latest published version:</dt><dd><a href="https://www.w3.org/TR/media-source/">https://www.w3.org/TR/media-source/</a></dd>
+    <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/media-source/">https://w3c.github.io/media-source/</a></dd>
+    
+    <dt>Implementation report:</dt><dd><a href="http://tidoust.github.io/media-source-testcoverage/">http://tidoust.github.io/media-source-testcoverage/</a></dd>
+    
+    
+    
+    
+    <dt>Editors:</dt>
+    <dd class="p-author h-card vcard"><span class="p-name fn">Matthew Wolenetz</span> (<a class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a>)</dd><dd class="p-author h-card vcard"><span class="p-name fn">Jerry Smith</span> (<a class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a>)</dd><dd class="p-author h-card vcard"><span class="p-name fn">Mark Watson</span> (<a class="p-org org h-org h-card" href="http://www.netflix.com/">Netflix Inc.</a>)</dd><dd class="p-author h-card vcard"><span class="p-name fn">Aaron Colwell (until April 2015)</span> (<a class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a>)</dd><dd class="p-author h-card vcard"><span class="p-name fn">Adrian Bateman (until April 2015)</span> (<a class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a>)</dd>
+    
+    
+    <dt>Repository:</dt><dd>
+      <a href="https://github.com/w3c/media-source/">We are on GitHub</a>
+    </dd><dd>
+      <a href="https://github.com/w3c/media-source/issues">File a bug</a>
+    </dd><dd>
+      <a href="https://github.com/w3c/media-source/commits/gh-pages/media-source-respec.html">Commit history</a>
+    </dd><dt>Mailing list:</dt><dd>
+      <a href="https://lists.w3.org/Archives/Public/public-html-media/">public-html-media@w3.org</a>
+    </dd><dt>Implementation:</dt><dd>
+      <a href="http://caniuse.com/#feat=mediasource">Can I use Media Source Extensions?</a>
+    </dd><dd>
+      <a href="http://w3c-test.org/media-source/">Test Suite</a>
+    </dd><dd>
+      <a href="https://github.com/w3c/web-platform-tests/tree/master/media-source">Test Suite repository</a>
+    </dd>
+  </dl>
+  <p>
+      Please check the <a href="https://w3c.github.io/media-source/mse-1-errata.html"><strong>errata</strong></a> for any errors or issues
+      reported since publication.
     </p>
-    <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions™</h1>
-    <h2 id="w3c-editor-s-draft-08-november-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-11-08">08 November 2016</time></h2>
-    <dl>
-      <dt>This version:</dt>
-      <dd><a class="u-url" href="http://w3c.github.io/media-source/">http://w3c.github.io/media-source/</a></dd>
-      <dt>Latest published version:</dt>
-      <dd><a href="https://www.w3.org/TR/media-source/">https://www.w3.org/TR/media-source/</a></dd>
-      <dt>Latest editor's draft:</dt>
-      <dd><a href="http://w3c.github.io/media-source/">http://w3c.github.io/media-source/</a></dd>
-      <dt>Implementation report:</dt>
-      <dd><a href="http://tidoust.github.io/media-source-testcoverage/">http://tidoust.github.io/media-source-testcoverage/</a></dd>
-      <dt>Editors:</dt>
-      <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
-        <span property="rdf:rest" resource="_:editor1"></span>
-      </dd>
-      <dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jerry Smith</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
-        <span property="rdf:rest" resource="_:editor2"></span>
-      </dd>
-      <dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Mark Watson</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.netflix.com/">Netflix Inc.</a></span>
-        <span property="rdf:rest" resource="_:editor3"></span>
-      </dd>
-      <dd class="p-author h-card vcard" resource="_:editor3"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
-        <span property="rdf:rest" resource="_:editor4"></span>
-      </dd>
-      <dd class="p-author h-card vcard" resource="_:editor4"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Adrian Bateman (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
-        <span property="rdf:rest" resource="rdf:nil"></span>
-      </dd>
+  
+  
+  <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        2018
+        
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a>
+        rules apply.
+      </p>
+  <hr title="Separator for header">
+</div>
 
-      <dt>Repository:</dt>
-      <dd>
-        <a href="https://github.com/w3c/media-source/">
-                      We are on GitHub
-                    </a>
-      </dd>
-      <dd>
-        <a href="https://github.com/w3c/media-source/issues">
-                      File a bug
-                    </a>
-      </dd>
-      <dd>
-        <a href="https://github.com/w3c/media-source/commits/gh-pages/media-source-respec.html">
-                      Commit history
-                    </a>
-      </dd>
-      <dt>Mailing list:</dt>
-      <dd>
-        <a href="https://lists.w3.org/Archives/Public/public-html-media/">
-                      public-html-media@w3.org
-                    </a>
-      </dd>
-      <dt>Implementation:</dt>
-      <dd>
-        <a href="http://caniuse.com/#feat=mediasource">
-                      Can I use Media Source Extensions?
-                    </a>
-      </dd>
-      <dd>
-        <a href="http://w3c-test.org/media-source/">
-                      Test Suite
-                    </a>
-      </dd>
-      <dd>
-        <a href="https://github.com/w3c/web-platform-tests/tree/master/media-source">
-                      Test Suite repository
-                    </a>
-      </dd>
-    </dl>
-    <p class="copyright">
-      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
+    <section id="sotd" class="introductory"><h2 id="status-of-this-document">Status of This Document</h2><p>
+        <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at https://www.w3.org/TR/.</em>
+      </p><p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports</a>. New features for this specification are expected to be incubated in the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a>.</p><p>One editorial issue (<a href="https://github.com/w3c/media-source/issues/168">removing the exposure of <code>createObjectURL(mediaSource)</code> in workers</a>) was addressed since the previous publication. For the list of changes done since the previous version, see the <a href="https://github.com/w3c/media-source/commits/gh-pages">commits</a>.</p><p>
+          By publishing this Recommendation, <abbr title="World Wide Web Consortium">W3C</abbr> expects the functionality specified in this Recommendation will not be affected by changes to File API. The Working Group will continue to track these specifications.
+        </p><p>
+          This document was published by the <a href="https://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
+          
+          
+            Comments regarding this document are welcome. Please send them to
+            <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
+            (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
+            <a href="https://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
+          
+          
+          
+          
+        </p><p>
+            Please see the Working Group's  <a href="http://tidoust.github.io/media-source-testcoverage/">implementation
+            report</a>.
+          </p><p>
+            Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+            Membership. This is a draft document and may be updated, replaced or obsoleted by other
+            documents at any time. It is inappropriate to cite this document as other than work in
+            progress.
+          </p><p>
+          
+            This document was produced by
+            a group
+            operating under the
+            <a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+          
+          
+          
+              <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a rel="disclosure" href="https://www.w3.org/2004/01/pp-impl/40318/status">public list of any patent
+              disclosures</a>
+            made in connection with the deliverables of
+            the group; that page also includes
+            instructions for disclosing a patent. An individual who has actual knowledge of a patent
+            which the individual believes contains
+            <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential
+            Claim(s)</a> must disclose the information in accordance with
+            <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section
+            6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+          
+          
+        </p><p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2018/Process-20180201/">1 February 2018 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+        </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a><ol class="toc"><li class="tocline"><a href="#goals" class="tocxref"><span class="secno">1.1 </span>Goals</a></li><li class="tocline"><a href="#definitions" class="tocxref"><span class="secno">1.2 </span>Definitions</a></li></ol></li><li class="tocline"><a href="#mediasource" class="tocxref"><span class="secno">2. </span>MediaSource Object</a><ol class="toc"><li class="tocline"><a href="#attributes" class="tocxref"><span class="secno">2.1 </span>Attributes</a></li><li class="tocline"><a href="#methods" class="tocxref"><span class="secno">2.2 </span>Methods</a></li><li class="tocline"><a href="#mediasource-events" class="tocxref"><span class="secno">2.3 </span>Event Summary</a></li><li class="tocline"><a href="#mediasource-algorithms" class="tocxref"><span class="secno">2.4 </span>Algorithms</a><ol class="toc"><li class="tocline"><a href="#mediasource-attach" class="tocxref"><span class="secno">2.4.1 </span>Attaching to a media element</a></li><li class="tocline"><a href="#mediasource-detach" class="tocxref"><span class="secno">2.4.2 </span>Detaching from a media element</a></li><li class="tocline"><a href="#mediasource-seeking" class="tocxref"><span class="secno">2.4.3 </span>Seeking</a></li><li class="tocline"><a href="#buffer-monitoring" class="tocxref"><span class="secno">2.4.4 </span>SourceBuffer Monitoring</a></li><li class="tocline"><a href="#active-source-buffer-changes" class="tocxref"><span class="secno">2.4.5 </span>Changes to selected/enabled track state</a></li><li class="tocline"><a href="#duration-change-algorithm" class="tocxref"><span class="secno">2.4.6 </span>Duration change</a></li><li class="tocline"><a href="#end-of-stream-algorithm" class="tocxref"><span class="secno">2.4.7 </span>End of stream algorithm</a></li></ol></li></ol></li><li class="tocline"><a href="#sourcebuffer" class="tocxref"><span class="secno">3. </span>SourceBuffer Object</a><ol class="toc"><li class="tocline"><a href="#attributes-0" class="tocxref"><span class="secno">3.1 </span>Attributes</a></li><li class="tocline"><a href="#methods-0" class="tocxref"><span class="secno">3.2 </span>Methods</a></li><li class="tocline"><a href="#track-buffers" class="tocxref"><span class="secno">3.3 </span>Track Buffers</a></li><li class="tocline"><a href="#sourcebuffer-events" class="tocxref"><span class="secno">3.4 </span>Event Summary</a></li><li class="tocline"><a href="#sourcebuffer-algorithms" class="tocxref"><span class="secno">3.5 </span>Algorithms</a><ol class="toc"><li class="tocline"><a href="#sourcebuffer-segment-parser-loop" class="tocxref"><span class="secno">3.5.1 </span>Segment Parser Loop</a></li><li class="tocline"><a href="#sourcebuffer-reset-parser-state" class="tocxref"><span class="secno">3.5.2 </span>Reset Parser State</a></li><li class="tocline"><a href="#sourcebuffer-append-error" class="tocxref"><span class="secno">3.5.3 </span>Append Error Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-prepare-append" class="tocxref"><span class="secno">3.5.4 </span>Prepare Append Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-buffer-append" class="tocxref"><span class="secno">3.5.5 </span>Buffer Append Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-range-removal" class="tocxref"><span class="secno">3.5.6 </span>Range Removal</a></li><li class="tocline"><a href="#sourcebuffer-init-segment-received" class="tocxref"><span class="secno">3.5.7 </span>Initialization Segment Received</a></li><li class="tocline"><a href="#sourcebuffer-coded-frame-processing" class="tocxref"><span class="secno">3.5.8 </span>Coded Frame Processing</a></li><li class="tocline"><a href="#sourcebuffer-coded-frame-removal" class="tocxref"><span class="secno">3.5.9 </span>Coded Frame Removal Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-coded-frame-eviction" class="tocxref"><span class="secno">3.5.10 </span>Coded Frame Eviction Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-audio-splice-frame-algorithm" class="tocxref"><span class="secno">3.5.11 </span>Audio Splice Frame Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-audio-splice-rendering-algorithm" class="tocxref"><span class="secno">3.5.12 </span>Audio Splice Rendering Algorithm</a></li><li class="tocline"><a href="#sourcebuffer-text-splice-frame-algorithm" class="tocxref"><span class="secno">3.5.13 </span>Text Splice Frame Algorithm</a></li></ol></li></ol></li><li class="tocline"><a href="#sourcebufferlist" class="tocxref"><span class="secno">4. </span>SourceBufferList Object</a><ol class="toc"><li class="tocline"><a href="#attributes-1" class="tocxref"><span class="secno">4.1 </span>Attributes</a></li><li class="tocline"><a href="#methods-1" class="tocxref"><span class="secno">4.2 </span>Methods</a></li><li class="tocline"><a href="#sourcebufferlist-events" class="tocxref"><span class="secno">4.3 </span>Event Summary</a></li></ol></li><li class="tocline"><a href="#url" class="tocxref"><span class="secno">5. </span>URL Object Extensions</a><ol class="toc"><li class="tocline"><a href="#methods-2" class="tocxref"><span class="secno">5.1 </span>Methods</a></li></ol></li><li class="tocline"><a href="#htmlmediaelement-extensions" class="tocxref"><span class="secno">6. </span>HTMLMediaElement Extensions</a></li><li class="tocline"><a href="#audio-track-extensions" class="tocxref"><span class="secno">7. </span>AudioTrack Extensions</a></li><li class="tocline"><a href="#video-track-extensions" class="tocxref"><span class="secno">8. </span>VideoTrack Extensions</a></li><li class="tocline"><a href="#text-track-extensions" class="tocxref"><span class="secno">9. </span>TextTrack Extensions</a></li><li class="tocline"><a href="#byte-stream-formats" class="tocxref"><span class="secno">10. </span>Byte Stream Formats</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">11. </span>Conformance</a></li><li class="tocline"><a href="#examples" class="tocxref"><span class="secno">12. </span>Examples</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">13. </span>Acknowledgments</a></li><li class="tocline"><a href="#VideoPlaybackQuality" class="tocxref"><span class="secno">A. </span>VideoPlaybackQuality</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">B. </span>References</a><ol class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">B.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">B.2 </span>Informative references</a></li></ol></li></ol></nav>
 
-      <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-      <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-      <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
-      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-      <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
-    </p>
-    <hr title="Separator for header">
-  </div>
+    <section id="abstract" class="introductory"><h2 id="abstract-0">Abstract</h2>
+      <p>This specification extends <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] to allow
+      JavaScript to generate media streams for playback.
+      Allowing JavaScript to generate streams facilitates a variety of use
+      cases like adaptive streaming and time shifting live streams.</p>
 
-
-
-  <section id="abstract" class="introductory" property="dc:abstract">
-    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
-    This specification extends <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] to allow JavaScript to generate media streams for playback. Allowing JavaScript to generate streams facilitates a variety of use cases like adaptive streaming and time shifting live streams.
-
-    <p>If you wish to make comments or file bugs regarding this document in a manner that is tracked by the editors, please submit them via
-      <a href="https://github.com/w3c/media-source/issues/new">our public bug database</a>.
-    </p>
-  </section>
-
-  <section id="sotd" class="introductory">
-    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
-    <p>
-      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at https://www.w3.org/TR/.</em>
-    </p>
-
-    <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>. This draft highlights some of the pending issues that are still to be discussed in the working group. No decision has been taken on the outcome of these issues including whether they are valid.</p>
-    <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
-
-    <p>
-      For this specification to exit the Candidate Recommendation stage, two independent implementations as detailed in the <a href="http://dev.w3.org/html5/decision-policy/public-permissive-exit-criteria.html">CR Exit Criteria (Public Permissive version 3)</a> document will be required to pass each test in the MSE test suite to be developed by the HTML Media Extensions WG.
-    </p>
-
-
-    <p>
-      This document was published by the <a href="https://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft. If you wish to make comments regarding this document, please send them to
-      <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
-      <a href="https://lists.w3.org/Archives/Public/public-html-media/">archives</a>). All comments are welcome.
-    </p>
-    <p>
-      Please see the Working Group's <a href="http://tidoust.github.io/media-source-testcoverage/">implementation
-              report</a>.
-    </p>
-    <p>
-      Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.
-    </p>
-    <p>
-      This document was produced by a group operating under the
-      <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-              Policy</a>.
-      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
-                disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
-      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-              Claim(s)</a> must disclose the information in accordance with
-      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-    </p>
-    <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
-    </p>
-
-  </section>
-  <nav id="toc">
-    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
-    <ol class="toc" role="directory">
-      <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
-        <ol class="toc">
-          <li class="tocline"><a href="#goals" class="tocxref"><span class="secno">1.1 </span>Goals</a></li>
-          <li class="tocline"><a href="#definitions" class="tocxref"><span class="secno">1.2 </span>Definitions</a></li>
-        </ol>
-      </li>
-      <li class="tocline"><a href="#mediasource" class="tocxref"><span class="secno">2. </span>MediaSource Object</a>
-        <ol class="toc">
-          <li class="tocline"><a href="#attributes" class="tocxref"><span class="secno">2.1 </span>Attributes</a></li>
-          <li class="tocline"><a href="#methods" class="tocxref"><span class="secno">2.2 </span>Methods</a></li>
-          <li class="tocline"><a href="#mediasource-events" class="tocxref"><span class="secno">2.3 </span>Event Summary</a></li>
-          <li class="tocline"><a href="#mediasource-algorithms" class="tocxref"><span class="secno">2.4 </span>Algorithms</a>
-            <ol class="toc">
-              <li class="tocline"><a href="#mediasource-attach" class="tocxref"><span class="secno">2.4.1 </span>Attaching to a media element</a></li>
-              <li class="tocline"><a href="#mediasource-detach" class="tocxref"><span class="secno">2.4.2 </span>Detaching from a media element</a></li>
-              <li class="tocline"><a href="#mediasource-seeking" class="tocxref"><span class="secno">2.4.3 </span>Seeking</a></li>
-              <li class="tocline"><a href="#buffer-monitoring" class="tocxref"><span class="secno">2.4.4 </span>SourceBuffer Monitoring</a></li>
-              <li class="tocline"><a href="#active-source-buffer-changes" class="tocxref"><span class="secno">2.4.5 </span>Changes to selected/enabled track state</a></li>
-              <li class="tocline"><a href="#duration-change-algorithm" class="tocxref"><span class="secno">2.4.6 </span>Duration change</a></li>
-              <li class="tocline"><a href="#end-of-stream-algorithm" class="tocxref"><span class="secno">2.4.7 </span>End of stream algorithm</a></li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li class="tocline"><a href="#sourcebuffer" class="tocxref"><span class="secno">3. </span>SourceBuffer Object</a>
-        <ol class="toc">
-          <li class="tocline"><a href="#attributes-1" class="tocxref"><span class="secno">3.1 </span>Attributes</a></li>
-          <li class="tocline"><a href="#methods-1" class="tocxref"><span class="secno">3.2 </span>Methods</a></li>
-          <li class="tocline"><a href="#track-buffers" class="tocxref"><span class="secno">3.3 </span>Track Buffers</a></li>
-          <li class="tocline"><a href="#sourcebuffer-events" class="tocxref"><span class="secno">3.4 </span>Event Summary</a></li>
-          <li class="tocline"><a href="#sourcebuffer-algorithms" class="tocxref"><span class="secno">3.5 </span>Algorithms</a>
-            <ol class="toc">
-              <li class="tocline"><a href="#sourcebuffer-segment-parser-loop" class="tocxref"><span class="secno">3.5.1 </span>Segment Parser Loop</a></li>
-              <li class="tocline"><a href="#sourcebuffer-reset-parser-state" class="tocxref"><span class="secno">3.5.2 </span>Reset Parser State</a></li>
-              <li class="tocline"><a href="#sourcebuffer-append-error" class="tocxref"><span class="secno">3.5.3 </span>Append Error Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-prepare-append" class="tocxref"><span class="secno">3.5.4 </span>Prepare Append Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-buffer-append" class="tocxref"><span class="secno">3.5.5 </span>Buffer Append Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-range-removal" class="tocxref"><span class="secno">3.5.6 </span>Range Removal</a></li>
-              <li class="tocline"><a href="#sourcebuffer-init-segment-received" class="tocxref"><span class="secno">3.5.7 </span>Initialization Segment Received</a></li>
-              <li class="tocline"><a href="#sourcebuffer-coded-frame-processing" class="tocxref"><span class="secno">3.5.8 </span>Coded Frame Processing</a></li>
-              <li class="tocline"><a href="#sourcebuffer-coded-frame-removal" class="tocxref"><span class="secno">3.5.9 </span>Coded Frame Removal Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-coded-frame-eviction" class="tocxref"><span class="secno">3.5.10 </span>Coded Frame Eviction Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-audio-splice-frame-algorithm" class="tocxref"><span class="secno">3.5.11 </span>Audio Splice Frame Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-audio-splice-rendering-algorithm" class="tocxref"><span class="secno">3.5.12 </span>Audio Splice Rendering Algorithm</a></li>
-              <li class="tocline"><a href="#sourcebuffer-text-splice-frame-algorithm" class="tocxref"><span class="secno">3.5.13 </span>Text Splice Frame Algorithm</a></li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li class="tocline"><a href="#sourcebufferlist" class="tocxref"><span class="secno">4. </span>SourceBufferList Object</a>
-        <ol class="toc">
-          <li class="tocline"><a href="#attributes-2" class="tocxref"><span class="secno">4.1 </span>Attributes</a></li>
-          <li class="tocline"><a href="#methods-2" class="tocxref"><span class="secno">4.2 </span>Methods</a></li>
-          <li class="tocline"><a href="#sourcebufferlist-events" class="tocxref"><span class="secno">4.3 </span>Event Summary</a></li>
-        </ol>
-      </li>
-      <li class="tocline"><a href="#url" class="tocxref"><span class="secno">5. </span>URL Object Extensions</a>
-        <ol class="toc">
-          <li class="tocline"><a href="#methods-3" class="tocxref"><span class="secno">5.1 </span>Methods</a></li>
-        </ol>
-      </li>
-      <li class="tocline"><a href="#htmlmediaelement-extensions" class="tocxref"><span class="secno">6. </span>HTMLMediaElement Extensions</a></li>
-      <li class="tocline"><a href="#audio-track-extensions" class="tocxref"><span class="secno">7. </span>AudioTrack Extensions</a></li>
-      <li class="tocline"><a href="#video-track-extensions" class="tocxref"><span class="secno">8. </span>VideoTrack Extensions</a></li>
-      <li class="tocline"><a href="#text-track-extensions" class="tocxref"><span class="secno">9. </span>TextTrack Extensions</a></li>
-      <li class="tocline"><a href="#byte-stream-formats" class="tocxref"><span class="secno">10. </span>Byte Stream Formats</a></li>
-      <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">11. </span>Conformance</a></li>
-      <li class="tocline"><a href="#examples" class="tocxref"><span class="secno">12. </span>Examples</a></li>
-      <li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">13. </span>Acknowledgments</a></li>
-      <li class="tocline"><a href="#VideoPlaybackQuality" class="tocxref"><span class="secno">A. </span>VideoPlaybackQuality</a></li>
-      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">B. </span>References</a>
-        <ol class="toc">
-          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">B.1 </span>Normative references</a></li>
-          <li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">B.2 </span>Informative references</a></li>
-        </ol>
-      </li>
-    </ol>
-  </nav>
-
-
-  <section id="introduction" class="informative" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span>
-    </h2>
-    <p><em>This section is non-normative.</em></p>
-    <p>This specification allows JavaScript to dynamically construct media streams for &lt;audio&gt; and &lt;video&gt;. It defines a MediaSource object that can serve as a source of media data for an HTMLMediaElement. MediaSource objects have one or more <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects. Applications append data segments to the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects, and can adapt the quality of appended data based on system performance and other factors. Data from the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects is managed as track buffers for audio, video and text data that is decoded and played. Byte stream specifications used with these extensions are available in the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>].</p>
-    <img src="pipeline_model.svg" alt="Media Source Pipeline Model Diagram" longdesc="pipeline_model_description.html#pipelinedesc">
-
-    <section id="goals" typeof="bibo:Chapter" resource="#goals" property="bibo:hasPart">
-      <h3 id="h-goals" resource="#h-goals"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Goals</span>
-      </h3>
-      <p>This specification was designed with the following goals in mind:</p>
-      <ul>
-        <li>Allow JavaScript to construct media streams independent of how the media is fetched.</li>
-        <li>Define a splicing and buffering model that facilitates use cases like adaptive streaming, ad-insertion, time-shifting, and video editing.</li>
-        <li>Minimize the need for media parsing in JavaScript.</li>
-        <li>Leverage the browser cache as much as possible.</li>
-        <li>Provide requirements for byte stream format specifications.</li>
-        <li>Not require support for any particular media format or codec.</li>
-      </ul>
-      <p>This specification defines:</p>
-      <ul>
-        <li>Normative behavior for user agents to enable interoperability between user agents and web applications when processing media data.</li>
-        <li>Normative requirements to enable other specifications to define media formats to be used within this specification.</li>
-      </ul>
+      <p>This version of the specification is intended for incubating a new codec switching feature, as
+      outlined in <a href="https://github.com/wicg/media-source/blob/codec-switching/codec-switching-explainer.md">the Codec Switching Explainer</a>.</p>
     </section>
 
-    <section id="definitions" typeof="bibo:Chapter" resource="#definitions" property="bibo:hasPart">
-      <h3 id="h-definitions" resource="#h-definitions"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Definitions</span>
-      </h3>
+    <section id="introduction" class="informative">
+      <!--OddPage--><h2 id="x1-introduction"><span class="secno">1. </span>Introduction</h2><p><em>This section is non-normative.</em></p>
+      <p>This specification allows JavaScript to dynamically construct media streams for &lt;audio&gt; and &lt;video&gt;. It defines a MediaSource object that can serve as a source of media data for an HTMLMediaElement. MediaSource objects have one or more <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects.  Applications append data segments to the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects, and can adapt the quality of appended data based on system performance and other factors. Data from the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects is managed as track buffers for audio, video and text data that is decoded and played. Byte stream specifications used with these extensions are available in the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>].</p>
+      <img src="pipeline_model.svg" alt="Media Source Pipeline Model Diagram" longdesc="pipeline_model_description.html#pipelinedesc" height="150" width="150">
+      <section id="goals">
+        <h3 id="x1-1-goals"><span class="secno">1.1 </span>Goals</h3>
+        <p>This specification was designed with the following goals in mind:</p>
+        <ul>
+          <li>Allow JavaScript to construct media streams independent of how the media is fetched.</li>
+          <li>Define a splicing and buffering model that facilitates use cases like adaptive streaming, ad-insertion, time-shifting, and video editing.</li>
+          <li>Minimize the need for media parsing in JavaScript.</li>
+          <li>Leverage the browser cache as much as possible.</li>
+          <li>Provide requirements for byte stream format specifications.</li>
+          <li>Not require support for any particular media format or codec.</li>
+        </ul>
+        <p>This specification defines:</p>
+        <ul>
+          <li>Normative behavior for user agents to enable interoperability between user agents and web applications when processing media data.</li>
+          <li>Normative requirements to enable other specifications to define media formats to be used within this specification.</li>
+        </ul>
+      </section>
 
-      <dl>
-        <dt id="active-track-buffers">Active Track Buffers</dt>
-        <dd>
-          <p>The <a href="#track-buffer">track buffers</a> that provide <a href="#coded-frame">coded frames</a> for the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code>
-            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code>, the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code>, and the
-            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-texttracks">textTracks</a></code>. All these tracks are associated with
+      <section id="definitions">
+        <h3 id="x1-2-definitions"><span class="secno">1.2 </span>Definitions</h3>
+
+        <dl>
+          <dt id="active-track-buffers">Active Track Buffers</dt>
+          <dd><p>The <a href="#track-buffer">track buffers</a> that provide <a href="#coded-frame">coded frames</a> for the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code>
+              <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code>, the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code>, and the
+              <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-texttracks">textTracks</a></code>. All these tracks are associated with
             <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in the <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> list.</p>
-        </dd>
+          </dd>
 
-        <dt id="append-window">Append Window</dt>
-        <dd>
-          <p>A <a href="#presentation-timestamp">presentation timestamp</a> range used to filter out <a href="#coded-frame">coded frames</a> while appending. The append window represents a single continuous time range with a single start time and end time. Coded frames with <a href="#presentation-timestamp">presentation timestamp</a> within this range are allowed to be appended to the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> while coded frames outside this range are filtered out. The append window start and end times are controlled by the <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> and <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> attributes respectively.</p>
-        </dd>
+          <dt id="append-window">Append Window</dt>
+          <dd><p>A <a href="#presentation-timestamp">presentation timestamp</a> range used to filter out <a href="#coded-frame">coded frames</a> while appending. The append window represents a single
+            continuous time range with a single start time and end time. Coded frames with <a href="#presentation-timestamp">presentation timestamp</a> within this range are allowed to be appended
+            to the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> while coded frames outside this range are filtered out. The append window start and end times are controlled by
+            the <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> and <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> attributes respectively.</p></dd>
 
-        <dt id="coded-frame">Coded Frame</dt>
-        <dd>
-          <p>A unit of media data that has a <a href="#presentation-timestamp">presentation timestamp</a>, a <a href="#decode-timestamp">decode timestamp</a>, and a <a href="#coded-frame-duration">coded frame duration</a>.</p>
-        </dd>
+          <dt id="coded-frame">Coded Frame</dt>
+          <dd><p>A unit of media data that has a <a href="#presentation-timestamp">presentation timestamp</a>, a <a href="#decode-timestamp">decode timestamp</a>, and a <a href="#coded-frame-duration">coded frame duration</a>.</p></dd>
 
-        <dt id="coded-frame-duration">Coded Frame Duration</dt>
-        <dd>
-          <p>The duration of a <a href="#coded-frame">coded frame</a>. For video and text, the duration indicates how long the video frame or text <em class="rfc2119" title="SHOULD">SHOULD</em> be displayed. For audio, the duration represents the sum of all the samples contained within the coded frame. For example, if an audio frame contained 441 samples @44100Hz the frame duration would be 10 milliseconds.</p>
-        </dd>
+          <dt id="coded-frame-duration">Coded Frame Duration</dt>
+          <dd>
+            <p>The duration of a <a href="#coded-frame">coded frame</a>. For video and text, the duration indicates how long the video frame or text <em class="rfc2119" title="SHOULD">SHOULD</em> be displayed. For audio, the duration represents the sum of all the samples contained within the coded frame. For example, if an audio frame contained 441 samples @44100Hz the frame duration would be 10 milliseconds.</p>
+          </dd>
 
-        <dt id="coded-frame-end-timestamp">Coded Frame End Timestamp</dt>
-        <dd>
-          <p>The sum of a <a href="#coded-frame">coded frame</a> <a href="#presentation-timestamp">presentation timestamp</a> and its
-            <a href="#coded-frame-duration">coded frame duration</a>. It represents the <a href="#presentation-timestamp">presentation timestamp</a> that immediately follows the coded frame.</p>
-        </dd>
+          <dt id="coded-frame-end-timestamp">Coded Frame End Timestamp</dt>
+          <dd>
+            <p>The sum of a <a href="#coded-frame">coded frame</a> <a href="#presentation-timestamp">presentation timestamp</a> and its
+                <a href="#coded-frame-duration">coded frame duration</a>. It represents the <a href="#presentation-timestamp">presentation timestamp</a> that immediately follows the coded frame.</p>
+          </dd>
 
-        <dt id="coded-frame-group">Coded Frame Group</dt>
-        <dd>
-          <p>A group of <a href="#coded-frame">coded frames</a> that are adjacent and have monotonically increasing <a href="#decode-timestamp">decode timestamps</a> without any gaps. Discontinuities detected by the
-            <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> and <code><a href="#dom-sourcebuffer-abort">abort()</a></code> calls trigger the start of a new coded frame group.</p>
-        </dd>
+          <dt id="coded-frame-group">Coded Frame Group</dt>
+          <dd><p>A group of <a href="#coded-frame">coded frames</a> that are adjacent and have monotonically increasing <a href="#decode-timestamp">decode timestamps</a> without any gaps. Discontinuities detected by the
+              <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> and <code><a href="#dom-sourcebuffer-abort">abort()</a></code> calls trigger the start of a new coded frame group.</p>
+          </dd>
 
-        <dt id="decode-timestamp">Decode Timestamp</dt>
-        <dd>
-          <p> The decode timestamp indicates the latest time at which the frame needs to be decoded assuming instantaneous decoding and rendering of this and any dependant frames (this is equal to the <a href="#presentation-timestamp">presentation timestamp</a> of the earliest frame, in <a href="#presentation-order">presentation order</a>, that is dependant on this frame). If frames can be decoded out of <a href="#presentation-order">presentation order</a>, then the decode timestamp <em class="rfc2119" title="MUST">MUST</em> be present in or derivable from the byte stream. The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> if this is not the case. If frames cannot be decoded out of <a href="#presentation-order">presentation order</a> and a decode timestamp is not present in the byte stream, then the decode timestamp is equal to the <a href="#presentation-timestamp">presentation timestamp</a>.</p>
-        </dd>
+          <dt id="decode-timestamp">Decode Timestamp</dt>
+          <dd>
+            <p> The decode timestamp indicates the latest time at which the frame needs to be decoded assuming instantaneous decoding and rendering of this and any dependant frames (this is equal to the <a href="#presentation-timestamp">presentation timestamp</a> of the earliest frame, in <a href="#presentation-order">presentation order</a>, that is dependant on this frame). If frames can be decoded out of <a href="#presentation-order">presentation order</a>, then the decode timestamp <em class="rfc2119" title="MUST">MUST</em> be present in or derivable from the byte stream. The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> if this is not the case. If frames cannot be decoded out of  <a href="#presentation-order">presentation order</a> and a decode timestamp is not present in the byte stream, then the decode timestamp is equal to the <a href="#presentation-timestamp">presentation timestamp</a>.</p>
+          </dd>
 
-        <dt id="init-segment">Initialization Segment</dt>
-        <dd>
-          <p>A sequence of bytes that contain all of the initialization information required to decode a sequence of <a href="#media-segment">media segments</a>. This includes codec initialization data, <a href="#track-id">Track ID</a> mappings for multiplexed segments, and timestamp offsets (e.g., edit lists).</p>
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note1"><span>Note</span></div>
-            <p class="">The <a href="#byte-stream-format-specs">byte stream format specifications</a> in the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] contain format specific examples.</p>
-          </div>
+          <dt id="init-segment">Initialization Segment</dt>
+          <dd>
+            <p>A sequence of bytes that contain all of the initialization information required to decode a sequence of <a href="#media-segment">media segments</a>. This includes codec initialization data, <a href="#track-id">Track ID</a> mappings for multiplexed segments, and timestamp offsets (e.g., edit lists).</p>
+            <div class="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="4"><span>Note</span></div><p class="">The <a href="#byte-stream-format-specs">byte stream format specifications</a> in the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] contain format specific examples.</p></div>
 
-        </dd><dt id="media-segment">Media Segment</dt>
-        <dd>
-          <p>A sequence of bytes that contain packetized &amp; timestamped media data for a portion of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-timeline">media timeline</a>. Media segments are always associated with the most recently appended <a href="#init-segment">initialization segment</a>.</p>
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note2"><span>Note</span></div>
-            <p class="">The <a href="#byte-stream-format-specs">byte stream format specifications</a> in the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] contain format specific examples.</p>
-          </div>
-        </dd>
+          </dd><dt id="media-segment">Media Segment</dt>
+          <dd>
+            <p>A sequence of bytes that contain packetized &amp; timestamped media data for a portion of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-timeline">media timeline</a>. Media segments are always associated with the most recently appended <a href="#init-segment">initialization segment</a>.</p>
+            <div class="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="4"><span>Note</span></div><p class="">The <a href="#byte-stream-format-specs">byte stream format specifications</a> in the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] contain format specific examples.</p></div>
+          </dd>
 
-        <dt id="mediasource-object-url">MediaSource object URL</dt>
-        <dd>
-          <p>A MediaSource object URL is a unique <a href="https://www.w3.org/TR/FileAPI/#url">Blob URI</a> [<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] created by <code><a href="#dom-url-createobjecturl">createObjectURL()</a></code>. It is used to attach a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object to an HTMLMediaElement.</p>
-          <p>These URLs are the same as a <a href="https://www.w3.org/TR/FileAPI/#url">Blob URI</a>, except that anything in the definition of that feature that refers to <a href="https://www.w3.org/TR/FileAPI/#dfn-file">File</a> and <a href="https://www.w3.org/TR/FileAPI/#dfn-Blob">Blob</a> objects is hereby extended to also apply to <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> objects.</p>
-          <p>The <a href="https://www.w3.org/TR/html51/browsers.html#section-origin">origin</a> of the MediaSource object URL is the <a href="https://www.w3.org/TR/html51/webappapis.html#relevant-settings-object">relevant settings object</a> of <code>this</code> during the call to <code><a href="#dom-url-createobjecturl">createObjectURL()</a></code>.</p>
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note3"><span>Note</span></div>
-            <p class="">For example, the <a href="https://www.w3.org/TR/html51/browsers.html#section-origin">origin</a> of the MediaSource object URL affects the way that the media element is <a href="https://www.w3.org/TR/html51/semantics-scripting.html#security-with-canvas-elements">consumed by canvas</a>.</p>
-          </div>
-        </dd>
+          <dt id="mediasource-object-url">MediaSource object URL</dt>
+          <dd>
+            <p>A MediaSource object URL is a unique <a href="https://www.w3.org/TR/FileAPI/#url">Blob URI</a> [<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] created by <code><a href="#dom-url-createobjecturl">createObjectURL()</a></code>. It is used to attach a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object to an HTMLMediaElement.</p>
+            <p>These URLs are the same as a <a href="https://www.w3.org/TR/FileAPI/#url">Blob URI</a>, except that anything in the definition of that feature that refers to <a href="https://www.w3.org/TR/FileAPI/#dfn-file">File</a> and <a href="https://www.w3.org/TR/FileAPI/#dfn-Blob">Blob</a> objects is hereby extended to also apply to <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> objects.</p>
+            <p>The <a href="https://www.w3.org/TR/html51/browsers.html#section-origin">origin</a> of the MediaSource object URL is the <a href="https://www.w3.org/TR/html51/webappapis.html#relevant-settings-object">relevant settings object</a> of <code>this</code> during the call to <code><a href="#dom-url-createobjecturl">createObjectURL()</a></code>.</p>
+            <div class="note" id="issue-container-generatedID-1"><div role="heading" class="note-title marker" id="h-note-1" aria-level="4"><span>Note</span></div><p class="">For example, the <a href="https://www.w3.org/TR/html51/browsers.html#section-origin">origin</a> of the MediaSource object URL affects the way that the media element is <a href="https://www.w3.org/TR/html51/semantics-scripting.html#security-with-canvas-elements">consumed by canvas</a>.</p></div>
+          </dd>
 
-        <dt id="parent-media-source">Parent Media Source</dt>
-        <dd>
-          <p>The parent media source of a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object is the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object that created it.</p>
-        </dd>
+          <dt id="parent-media-source">Parent Media Source</dt>
+          <dd><p>The parent media source of a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object is the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object that created it.</p></dd>
 
-        <dt id="presentation-start-time">Presentation Start Time</dt>
-        <dd>
-          <p>The presentation start time is the earliest time point in the presentation and specifies the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#initial-playback-position">initial playback position</a> and <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#earliest-possible-position">earliest possible position</a>. All presentations created using this specification have a presentation start time of 0.</p>
+          <dt id="presentation-start-time">Presentation Start Time</dt>
+          <dd><p>The presentation start time is the earliest time point in the presentation and specifies the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#initial-playback-position">initial playback position</a> and <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#earliest-possible-position">earliest possible position</a>. All presentations created using this specification have a presentation start time of 0.</p>
 
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note4"><span>Note</span></div>
-            <p class="">For the purposes of determining if <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position, implementations <em class="rfc2119" title="MAY">MAY</em> choose to allow a current playback position at or after <a href="#presentation-start-time">presentation start time</a> and before the first <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> to play the first <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> if that <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> starts within a reasonably short time, like 1 second, after <a href="#presentation-start-time">presentation start time</a>. This allowance accommodates the reality that muxed streams commonly do not begin all tracks precisely at <a href="#presentation-start-time">presentation start time</a>. Implementations <em class="rfc2119" title="MUST">MUST</em> report the actual buffered range, regardless of this allowance.</p>
-          </div>
-        </dd>
-        <dt id="presentation-interval">Presentation Interval</dt>
-        <dd>
-          <p>The presentation interval of a <a href="#coded-frame">coded frame</a> is the time interval from its <a href="#presentation-timestamp">presentation timestamp</a> to the <a href="#presentation-timestamp">presentation timestamp</a> plus the <a href="#coded-frame-duration">coded frame's duration</a>. For example, if a coded frame has a presentation timestamp of 10 seconds and a <a href="#coded-frame-duration">coded frame duration</a> of 100 milliseconds, then the presentation interval would be [10-10.1). Note that the start of the range is inclusive, but the end of the range is exclusive.</p>
-        </dd>
+          <div class="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-2" aria-level="4"><span>Note</span></div><p class="">For the purposes of determining if <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position, implementations <em class="rfc2119" title="MAY">MAY</em> choose to allow a current playback position at or after <a href="#presentation-start-time">presentation start time</a> and before the first <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> to play the first <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> if that <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> starts within a reasonably short time, like 1 second, after <a href="#presentation-start-time">presentation start time</a>. This allowance accommodates the reality that muxed streams commonly do not begin all tracks precisely at <a href="#presentation-start-time">presentation start time</a>. Implementations <em class="rfc2119" title="MUST">MUST</em> report the actual buffered range, regardless of this allowance.</p></div>
+          </dd>
+          <dt id="presentation-interval">Presentation Interval</dt>
+          <dd>
+            <p>The presentation interval of a <a href="#coded-frame">coded frame</a> is the time interval from its <a href="#presentation-timestamp">presentation timestamp</a> to the <a href="#presentation-timestamp">presentation timestamp</a> plus the <a href="#coded-frame-duration">coded frame's duration</a>. For example, if a coded frame has a presentation timestamp of 10 seconds and a <a href="#coded-frame-duration">coded frame duration</a> of 100 milliseconds, then the presentation interval would be [10-10.1). Note that the start of the range is inclusive, but the end of the range is exclusive.</p>
+          </dd>
 
-        <dt id="presentation-order">Presentation Order</dt>
-        <dd>
-          <p>The order that <a href="#coded-frame">coded frames</a> are rendered in the presentation. The presentation order is achieved by ordering <a href="#coded-frame">coded frames</a> in monotonically increasing order by their <a href="#presentation-timestamp">presentation timestamps</a>.</p>
-        </dd>
+          <dt id="presentation-order">Presentation Order</dt>
+          <dd>
+            <p>The order that <a href="#coded-frame">coded frames</a> are rendered in the presentation. The presentation order is achieved by ordering <a href="#coded-frame">coded frames</a> in monotonically increasing order by their <a href="#presentation-timestamp">presentation timestamps</a>.</p>
+          </dd>
 
-        <dt id="presentation-timestamp">Presentation Timestamp</dt>
-        <dd>
-          <p>A reference to a specific time in the presentation. The presentation timestamp in a <a href="#coded-frame">coded frame</a> indicates when the frame <em class="rfc2119" title="SHOULD">SHOULD</em> be rendered.</p>
-        </dd>
+          <dt id="presentation-timestamp">Presentation Timestamp</dt>
+          <dd>
+             <p>A reference to a specific time in the presentation. The presentation timestamp in a <a href="#coded-frame">coded frame</a> indicates when the frame <em class="rfc2119" title="SHOULD">SHOULD</em> be rendered.</p>
+          </dd>
 
-        <dt id="random-access-point">Random Access Point</dt>
-        <dd>
-          <p>A position in a <a href="#media-segment">media segment</a> where decoding and continuous playback can begin without relying on any previous data in the segment. For video this tends to be the location of I-frames. In the case of audio, most audio frames can be treated as a random access point. Since video tracks tend to have a more sparse distribution of random access points, the location of these points are usually considered the random access points for multiplexed streams.</p>
-        </dd>
+          <dt id="random-access-point">Random Access Point</dt>
+          <dd><p>A position in a <a href="#media-segment">media segment</a> where decoding and continuous playback can begin without relying on any previous data in the segment. For video this tends to be the location of I-frames. In the case of audio, most audio frames can be treated as a random access point. Since video tracks tend to have a more sparse distribution of random access points, the location of these points are usually considered the random access points for multiplexed streams.</p></dd>
 
-        <dt id="sourcebuffer-byte-stream-format-spec">SourceBuffer byte stream format specification</dt>
-        <dd>
-          <p>The specific <a href="#byte-stream-format-specs">byte stream format specification</a> that describes the format of the byte stream accepted by a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> instance. The
-            <a href="#byte-stream-format-specs">byte stream format specification</a>, for a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object, is selected based on the <var>type</var> passed to the
-            <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> call that created the object.</p>
-        </dd>
+          <dt id="sourcebuffer-byte-stream-format-spec">SourceBuffer byte stream format specification</dt>
+          <dd><p>The specific <a href="#byte-stream-format-specs">byte stream format specification</a> that describes the format of the byte stream accepted by a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> instance. The
+              <a href="#byte-stream-format-specs">byte stream format specification</a>, for a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object, is initially selected based on the <var>type</var> passed to the
+              <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> call that created the object, and can be updated by <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> calls on the object.</p></dd>
 
-        <dt id="sourcebuffer-configuration">SourceBuffer configuration</dt>
-        <dd>
-          <p>A specific set of tracks distributed across one or more <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects owned by a single <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> instance.</p>
-          <p>Implementations <em class="rfc2119" title="MUST">MUST</em> support at least 1 <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object with the following configurations:
-          </p>
-          <ul>
-            <li>A single SourceBuffer with 1 audio track and/or 1 video track.</li>
-            <li>Two SourceBuffers with one handling a single audio track and the other handling a single video track.</li>
-          </ul>
-          <p>MediaSource objects <em class="rfc2119" title="MUST">MUST</em> support each of the configurations above, but they are only required to support one configuration at a time. Supporting multiple configurations at once or additional configurations is a quality of implementation issue.</p>
-        </dd>
+          <dt id="sourcebuffer-configuration">SourceBuffer configuration</dt>
+          <dd><p>A specific set of tracks distributed across one or more <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>
+              objects owned by a single <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> instance.</p>
+            <p>Implementations <em class="rfc2119" title="MUST">MUST</em> support at least 1 <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object with the following
+            configurations:</p>
+            <ul>
+              <li>A single SourceBuffer with 1 audio track and/or 1 video track.</li>
+              <li>Two SourceBuffers with one handling a single audio track and the other handling a single video track.</li>
+            </ul>
+            <p>MediaSource objects <em class="rfc2119" title="MUST">MUST</em> support each of the configurations above, but they are only
+              required to support one configuration at a time. Supporting multiple configurations at once
+              or additional configurations is a quality of implementation issue.</p>
+          </dd>
 
-        <dt id="track-description">Track Description</dt>
-        <dd>
-          <p>A byte stream format specific structure that provides the <a href="#track-id">Track ID</a>, codec configuration, and other metadata for a single track. Each track description inside a single <a href="#init-segment">initialization segment</a> has a unique <a href="#track-id">Track ID</a>. The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> if the <a href="#track-id">Track ID</a> is not unique within the <a href="#init-segment">initialization segment</a>.</p>
-        </dd>
+          <dt id="track-description">Track Description</dt>
+          <dd><p>A byte stream format specific structure that provides the <a href="#track-id">Track ID</a>, codec configuration, and other metadata for a single track. Each track description inside a single <a href="#init-segment">initialization segment</a> has a unique <a href="#track-id">Track ID</a>. The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> if the <a href="#track-id">Track ID</a> is not unique within the <a href="#init-segment">initialization segment</a>.</p></dd>
 
-        <dt id="track-id">Track ID</dt>
-        <dd>
-          <p>A Track ID is a byte stream format specific identifier that marks sections of the byte stream as being part of a specific track. The Track ID in a <a href="#track-description">track description</a> identifies which sections of a <a href="#media-segment">media segment</a> belong to that track.</p>
-        </dd>
+          <dt id="track-id">Track ID</dt>
+          <dd><p>A Track ID is a byte stream format specific identifier that marks sections of the byte stream as being part of a specific track. The Track ID in a <a href="#track-description">track description</a> identifies which sections of a <a href="#media-segment">media segment</a> belong to that track.</p></dd>
 
-      </dl>
+        </dl>
+      </section>
     </section>
-  </section>
 
-  <section id="mediasource" typeof="bibo:Chapter" resource="#mediasource" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-mediasource" resource="#h-mediasource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>MediaSource Object</span>
-    </h2>
-    <p>The MediaSource object represents a source of media data for an HTMLMediaElement. It keeps track of the <code><a href="#dom-readystate">readyState</a></code> for this source as well as a list of <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects that can be used to add media data to the presentation. MediaSource objects are created by the web application and then attached to an HTMLMediaElement. The application uses the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> to add media data to this source. The HTMLMediaElement fetches this media data from the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object when it is needed during playback.</p>
+    <section id="mediasource">
+      <!--OddPage--><h2 id="x2-mediasource-object"><span class="secno">2. </span>MediaSource Object</h2>
+      <p>The MediaSource object represents a source of media data for an HTMLMediaElement. It keeps track of the <code><a href="#dom-readystate">readyState</a></code> for this source as well as a list of <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects that can be used to add media data to the presentation. MediaSource objects are created by the web application and then attached to an HTMLMediaElement. The application uses the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> to add media data to this source. The HTMLMediaElement fetches this media data from the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object when it is needed during playback.</p>
 
-    <p>Each <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object has a <dfn id="live-seekable-range" data-dfn-type="dfn">live seekable range</dfn> variable that stores a <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a>. This variable is initialized to an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object when the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object is created, is maintained by <code><a href="#dom-mediasource-setliveseekablerange">setLiveSeekableRange()</a></code> and <code><a href="#dom-mediasource-clearliveseekablerange">clearLiveSeekableRange()</a></code>, and is used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-seekable">HTMLMediaElement.seekable</a></code> behavior.</p>
+      <p>Each <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object has a <dfn id="live-seekable-range" data-dfn-type="dfn">live seekable range</dfn> variable that stores a <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a>.  This variable is initialized to an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object when the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object is created, is maintained by <code><a href="#dom-mediasource-setliveseekablerange">setLiveSeekableRange()</a></code> and <code><a href="#dom-mediasource-clearliveseekablerange">clearLiveSeekableRange()</a></code>, and is used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-seekable">HTMLMediaElement.seekable</a></code> behavior.</p>
 
-    <div><pre class="def idl"><span class="idlEnum" id="idl-def-readystate" data-idl="" data-title="ReadyState">enum <span class="idlEnumID"><a data-lt="ReadyState" href="#idl-def-readystate" class="internalDFN" data-link-type="dfn" data-for=""><code>ReadyState</code></a></span> {
-    "<a href="#dom-readystate-closed" class="idlEnumItem">closed</a>",
-    "<a href="#dom-readystate-open" class="idlEnumItem">open</a>",
-    "<a href="#dom-readystate-ended" class="idlEnumItem">ended</a>"
-};</span></pre>
-      <table class="simple" data-dfn-for="ReadyState" data-link-for="ReadyState">
-        <tbody>
-          <tr>
-            <th colspan="2">Enumeration description</th>
-          </tr>
-          <tr>
-            <td><dfn data-dfn-for="readystate" data-dfn-type="dfn" id="dom-readystate-closed" data-idl=""><code id="idl-def-ReadyState.closed">closed</code></dfn></td>
-            <td>
-              Indicates the source is not currently attached to a media element.
-            </td>
-          </tr>
-          <tr>
-            <td><dfn data-dfn-for="readystate" data-dfn-type="dfn" id="dom-readystate-open" data-idl=""><code id="idl-def-ReadyState.open">open</code></dfn></td>
-            <td>
-              The source has been opened by a media element and is ready for data to be appended to the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.
-            </td>
-          </tr>
-          <tr>
-            <td><dfn data-dfn-for="readystate" data-dfn-type="dfn" id="dom-readystate-ended" data-idl=""><code id="idl-def-ReadyState.ended">ended</code></dfn></td>
-            <td>
-              The source is still attached to a media element, but <code><a href="#dom-mediasource-endofstream">endOfStream()</a></code> has been called.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+      <div><div><pre class="def idl"><span class="idlEnum" id="idl-def-readystate" data-idl="" data-title="ReadyState">enum <span class="idlEnumID"><a data-no-default="" data-link-for="" data-lt="" href="#idl-def-readystate" class="internalDFN" data-link-type="dfn">ReadyState</a></span> {
+    <a href="#dom-readystate-closed" class="idlEnumItem">"closed"</a>,
+    <a href="#dom-readystate-open" class="idlEnumItem">"open"</a>,
+    <a href="#dom-readystate-ended" class="idlEnumItem">"ended"</a>
+};</span></pre></div><table class="simple" data-dfn-for="ReadyState" data-link-for="ReadyState"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn data-dfn-for="readystate" data-dfn-type="dfn" id="dom-readystate-closed" data-idl="" data-title="closed"><code id="idl-def-ReadyState.closed">closed</code></dfn></td><td>
+          Indicates the source is not currently attached to a media element.
+        </td></tr><tr><td><dfn data-dfn-for="readystate" data-dfn-type="dfn" id="dom-readystate-open" data-idl="" data-title="open"><code id="idl-def-ReadyState.open">open</code></dfn></td><td>
+          The source has been opened by a media element and is ready for data to be appended to the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.
+        </td></tr><tr><td><dfn data-dfn-for="readystate" data-dfn-type="dfn" id="dom-readystate-ended" data-idl="" data-title="ended"><code id="idl-def-ReadyState.ended">ended</code></dfn></td><td>
+          The source is still attached to a media element, but <code><a href="#dom-mediasource-endofstream">endOfStream()</a></code> has been called.
+        </td></tr></tbody></table></div>
 
-    <div><pre class="def idl"><span class="idlEnum" id="idl-def-endofstreamerror" data-idl="" data-title="EndOfStreamError">enum <span class="idlEnumID">EndOfStreamError</span> {
-    "<a href="#dom-endofstreamerror-network" class="idlEnumItem">network</a>",
-    "<a href="#dom-endofstreamerror-decode" class="idlEnumItem">decode</a>"
-};</span></pre>
-      <table class="simple" data-dfn-for="EndOfStreamError" data-link-for="EndOfStreamError">
-        <tbody>
-          <tr>
-            <th colspan="2">Enumeration description</th>
-          </tr>
-          <tr>
-            <td><dfn data-dfn-for="endofstreamerror" data-dfn-type="dfn" id="dom-endofstreamerror-network" data-idl=""><code id="idl-def-EndOfStreamError.network">network</code></dfn></td>
-            <td>
-              <p>Terminates playback and signals that a network error has occured.</p>
-              <div class="note">
-                <div class="note-title marker" aria-level="3" role="heading" id="h-note5"><span>Note</span></div>
-                <p class="">JavaScript applications <em class="rfc2119" title="SHOULD">SHOULD</em> use this status code to terminate playback with a network error. For example, if a network error occurs while fetching media data.</p>
-              </div>
-            </td>
-          </tr>
-          <tr>
-            <td><dfn data-dfn-for="endofstreamerror" data-dfn-type="dfn" id="dom-endofstreamerror-decode" data-idl=""><code id="idl-def-EndOfStreamError.decode">decode</code></dfn></td>
-            <td>
-              <p>Terminates playback and signals that a decoding error has occured.</p>
-              <div class="note">
-                <div class="note-title marker" aria-level="3" role="heading" id="h-note6"><span>Note</span></div>
-                <p class="">JavaScript applications <em class="rfc2119" title="SHOULD">SHOULD</em> use this status code to terminate playback with a decode error. For example, if a parsing error occurs while processing out-of-band media data.</p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+      <div><div><pre class="def idl"><span class="idlEnum" id="idl-def-endofstreamerror" data-idl="" data-title="EndOfStreamError">enum <span class="idlEnumID">EndOfStreamError</span> {
+    <a href="#dom-endofstreamerror-network" class="idlEnumItem">"network"</a>,
+    <a href="#dom-endofstreamerror-decode" class="idlEnumItem">"decode"</a>
+};</span></pre></div><table class="simple" data-dfn-for="EndOfStreamError" data-link-for="EndOfStreamError"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn data-dfn-for="endofstreamerror" data-dfn-type="dfn" id="dom-endofstreamerror-network" data-idl="" data-title="network"><code id="idl-def-EndOfStreamError.network">network</code></dfn></td><td>
+          <p>Terminates playback and signals that a network error has occured.</p>
+          <div class="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-3" aria-level="3"><span>Note</span></div><p class="">JavaScript applications <em class="rfc2119" title="SHOULD">SHOULD</em> use this status code to terminate playback with a network error. For example, if a network error occurs while fetching media data.</p></div>
+        </td></tr><tr><td><dfn data-dfn-for="endofstreamerror" data-dfn-type="dfn" id="dom-endofstreamerror-decode" data-idl="" data-title="decode"><code id="idl-def-EndOfStreamError.decode">decode</code></dfn></td><td>
+          <p>Terminates playback and signals that a decoding error has occured.</p>
+          <div class="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-4" aria-level="3"><span>Note</span></div><p class="">JavaScript applications <em class="rfc2119" title="SHOULD">SHOULD</em> use this status code to terminate playback with a decode error. For example, if a parsing error occurs while processing out-of-band media data.</p></div>
+        </td></tr></tbody></table></div>
 
-    <pre class="def idl"><span class="idlInterface" id="idl-def-mediasource" data-idl="" data-title="MediaSource">[<span class="idlCtor"><span class="extAttrName">Constructor</span></span>]
+<div><pre class="def idl"><span class="idlInterface" id="idl-def-mediasource" data-idl="" data-title="MediaSource">[<span class="idlCtor"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#Constructor">Constructor</a></span></span>]
 interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSuperclass">EventTarget</span> {
-<span class="idlAttribute" id="idl-def-mediasource-sourcebuffers" data-idl="" data-title="sourceBuffers" data-dfn-for="mediasource">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>    <span class="idlAttrName"><a data-lt="sourceBuffers" href="#dom-mediasource-sourcebuffers" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>sourceBuffers</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediasource-activesourcebuffers" data-idl="" data-title="activeSourceBuffers" data-dfn-for="mediasource">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>    <span class="idlAttrName"><a data-lt="activeSourceBuffers" href="#dom-mediasource-activesourcebuffers" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>activeSourceBuffers</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediasource-readystate" data-idl="" data-title="readyState" data-dfn-for="mediasource">    readonly attribute <span class="idlAttrType"><a href="#idl-def-readystate" class="internalDFN" data-link-type="dfn"><code>ReadyState</code></a></span>          <span class="idlAttrName"><a href="#dom-readystate"><code>readyState</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediasource-duration" data-idl="" data-title="duration" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span> <span class="idlAttrName"><a data-lt="duration" href="#dom-mediasource-duration" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>duration</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediasource-onsourceopen" data-idl="" data-title="onsourceopen" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onsourceopen" href="#dom-mediasource-onsourceopen" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>onsourceopen</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediasource-onsourceended" data-idl="" data-title="onsourceended" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onsourceended" href="#dom-mediasource-onsourceended" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>onsourceended</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediasource-onsourceclose" data-idl="" data-title="onsourceclose" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onsourceclose" href="#dom-mediasource-onsourceclose" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>onsourceclose</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-mediasource-addsourcebuffer(domstring)" data-idl="" data-title="addSourceBuffer" data-dfn-for="mediasource">    <span class="idlMethType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span> <span class="idlMethName"><a data-lt="addSourceBuffer" href="#dom-mediasource-addsourcebuffer" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>addSourceBuffer</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlParamName">type</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediasource-removesourcebuffer(sourcebuffer)" data-idl="" data-title="removeSourceBuffer" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>         <span class="idlMethName"><a data-lt="removeSourceBuffer" href="#dom-mediasource-removesourcebuffer" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>removeSourceBuffer</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span> <span class="idlParamName">sourceBuffer</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediasource-endofstream(optional-endofstreamerror)" data-idl="" data-title="endOfStream" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>         <span class="idlMethName"><a data-lt="endOfStream" href="#dom-mediasource-endofstream" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>endOfStream</code></a></span>(<span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-endofstreamerror" class="internalDFN" data-link-type="dfn"><code>EndOfStreamError</code></a></span> <span class="idlParamName">error</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediasource-setliveseekablerange(double,double)" data-idl="" data-title="setLiveSeekableRange" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>         <span class="idlMethName"><a data-lt="setLiveSeekableRange" href="#dom-mediasource-setliveseekablerange" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>setLiveSeekableRange</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span> <span class="idlParamName">start</span></span>, <span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span> <span class="idlParamName">end</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediasource-clearliveseekablerange()" data-idl="" data-title="clearLiveSeekableRange" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>         <span class="idlMethName"><a data-lt="clearLiveSeekableRange" href="#dom-mediasource-clearliveseekablerange" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>clearLiveSeekableRange</code></a></span>();</span>
-<span class="idlMethod" id="idl-def-mediasource-istypesupported(domstring)" data-idl="" data-title="isTypeSupported" data-dfn-for="mediasource">    static <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></code></span> <span class="idlMethName"><a data-lt="isTypeSupported" href="#dom-mediasource-istypesupported" class="internalDFN" data-link-type="dfn" data-for="MediaSource"><code>isTypeSupported</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlParamName">type</span></span>);</span>
-};</span></pre>
-
-    <section id="attributes" typeof="bibo:Chapter" resource="#attributes" property="bibo:hasPart">
-      <h3 id="h-attributes" resource="#h-attributes"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1 </span>Attributes</span>
-      </h3>
-      <dl class="attributes" data-dfn-for="MediaSource" data-link-for="MediaSource"><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-sourcebuffers" data-idl=""><code>sourceBuffers</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>, readonly       </dt>
-        <dd>
+<span class="idlAttribute" id="idl-def-mediasource-sourcebuffers" data-idl="" data-title="sourceBuffers" data-dfn-for="mediasource">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>    <span class="idlAttrName"><a data-no-default="" data-link-for="mediasource" data-lt="" href="#dom-mediasource-sourcebuffers" class="internalDFN" data-link-type="dfn"><code>sourceBuffers</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediasource-activesourcebuffers" data-idl="" data-title="activeSourceBuffers" data-dfn-for="mediasource">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>    <span class="idlAttrName"><a data-no-default="" data-link-for="mediasource" data-lt="" href="#dom-mediasource-activesourcebuffers" class="internalDFN" data-link-type="dfn"><code>activeSourceBuffers</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediasource-readystate" data-idl="" data-title="readyState" data-dfn-for="mediasource">    readonly attribute <span class="idlAttrType"><a href="#idl-def-readystate" class="internalDFN" data-link-type="dfn">ReadyState</a></span>          <span class="idlAttrName"><a href="#dom-readystate"><code>readyState</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediasource-duration" data-idl="" data-title="duration" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span> <span class="idlAttrName"><a data-no-default="" data-link-for="mediasource" data-lt="" href="#dom-mediasource-duration" class="internalDFN" data-link-type="dfn"><code>duration</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediasource-onsourceopen" data-idl="" data-title="onsourceopen" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="mediasource" data-lt="" href="#dom-mediasource-onsourceopen" class="internalDFN" data-link-type="dfn"><code>onsourceopen</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediasource-onsourceended" data-idl="" data-title="onsourceended" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="mediasource" data-lt="" href="#dom-mediasource-onsourceended" class="internalDFN" data-link-type="dfn"><code>onsourceended</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediasource-onsourceclose" data-idl="" data-title="onsourceclose" data-dfn-for="mediasource">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="mediasource" data-lt="" href="#dom-mediasource-onsourceclose" class="internalDFN" data-link-type="dfn"><code>onsourceclose</code></a></span>;</span>
+<span class="idlMethod" id="idl-def-mediasource-addsourcebuffer-type" data-idl="" data-title="addSourceBuffer" data-dfn-for="mediasource">    <span class="idlMethType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span>   <span class="idlMethName"><a data-no-default="" data-link-for="mediasource" data-lt="addSourceBuffer|addsourcebuffer()" href="#dom-mediasource-addsourcebuffer" class="internalDFN" data-link-type="dfn"><code>addSourceBuffer</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlParamName">type</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediasource-removesourcebuffer-sourcebuffer" data-idl="" data-title="removeSourceBuffer" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>           <span class="idlMethName"><a data-no-default="" data-link-for="mediasource" data-lt="removeSourceBuffer|removesourcebuffer()" href="#dom-mediasource-removesourcebuffer" class="internalDFN" data-link-type="dfn"><code>removeSourceBuffer</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span> <span class="idlParamName">sourceBuffer</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediasource-endofstream-error" data-idl="" data-title="endOfStream" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>           <span class="idlMethName"><a data-no-default="" data-link-for="mediasource" data-lt="endOfStream|endofstream()" href="#dom-mediasource-endofstream" class="internalDFN" data-link-type="dfn"><code>endOfStream</code></a></span>(<span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-endofstreamerror" class="internalDFN" data-link-type="dfn"><code>EndOfStreamError</code></a></span> <span class="idlParamName">error</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediasource-setliveseekablerange-start-end" data-idl="" data-title="setLiveSeekableRange" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>           <span class="idlMethName"><a data-no-default="" data-link-for="mediasource" data-lt="setLiveSeekableRange|setliveseekablerange()" href="#dom-mediasource-setliveseekablerange" class="internalDFN" data-link-type="dfn"><code>setLiveSeekableRange</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span> <span class="idlParamName">start</span></span>, <span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span> <span class="idlParamName">end</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediasource-clearliveseekablerange" data-idl="" data-title="clearLiveSeekableRange" data-dfn-for="mediasource">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span>           <span class="idlMethName"><a data-no-default="" data-link-for="mediasource" data-lt="clearLiveSeekableRange|clearliveseekablerange()" href="#dom-mediasource-clearliveseekablerange" class="internalDFN" data-link-type="dfn"><code>clearLiveSeekableRange</code></a></span>();</span>
+<span class="idlMethod" id="idl-def-mediasource-istypesupported-type" data-idl="" data-title="isTypeSupported" data-dfn-for="mediasource">    static <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></code></span> <span class="idlMethName"><a data-no-default="" data-link-for="mediasource" data-lt="isTypeSupported|istypesupported()" href="#dom-mediasource-istypesupported" class="internalDFN" data-link-type="dfn"><code>isTypeSupported</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlParamName">type</span></span>);</span>
+};</span></pre></div>
+      <section id="attributes">
+        <h3 id="x2-1-attributes"><span class="secno">2.1 </span>Attributes</h3>
+        <dl class="attributes" data-dfn-for="MediaSource" data-link-for="MediaSource"><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-sourcebuffers" data-idl="" data-title="sourceBuffers"><code>sourceBuffers</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>, readonly       </dt><dd>
           Contains the list of <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects associated with this <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>. When <code><a href="#dom-readystate">readyState</a></code> equals <code><a href="#idl-def-ReadyState.closed">"closed"</a></code> this list will be empty. Once <code><a href="#dom-readystate">readyState</a></code> transitions to <code><a href="#idl-def-ReadyState.open">"open"</a></code> SourceBuffer objects can be added to this list by using <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code>.
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-activesourcebuffers" data-idl=""><code>activeSourceBuffers</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>, readonly       </dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-activesourcebuffers" data-idl="" data-title="activeSourceBuffers"><code>activeSourceBuffers</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a></span>, readonly       </dt><dd>
           <p>Contains the subset of <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> that are providing the
             <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected video track</a>, the
             <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled audio track(s)</a>, and the
             <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> text track(s).
           </p>
-          <p><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in this list <em class="rfc2119" title="MUST">MUST</em> appear in the same order as they appear in the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute; e.g., if only sourceBuffers[0] and sourceBuffers[3] are in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then activeSourceBuffers[0] <em class="rfc2119" title="MUST">MUST</em> equal sourceBuffers[0] and activeSourceBuffers[1] <em class="rfc2119" title="MUST">MUST</em> equal sourceBuffers[3].
+          <p><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in this list <em class="rfc2119" title="MUST">MUST</em> appear in the same order as they appear in
+            the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute; e.g., if only sourceBuffers[0] and
+            sourceBuffers[3] are in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then activeSourceBuffers[0] <em class="rfc2119" title="MUST">MUST</em>
+            equal sourceBuffers[0] and activeSourceBuffers[1] <em class="rfc2119" title="MUST">MUST</em> equal sourceBuffers[3].
           </p>
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note7"><span>Note</span></div>
-            <p class="">The <a href="#active-source-buffer-changes">Changes to selected/enabled track state</a> section describes how this attribute gets updated.
-            </p>
-          </div>
-        </dd><dt><dfn data-dfn-for="" data-dfn-type="dfn" id="dom-readystate" data-idl=""><code>readyState</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-mediasource-readystate" class="internalDFN" data-link-type="dfn"><code>ReadyState</code></a></span>, readonly       </dt>
-        <dd>
+          <div class="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-5" aria-level="4"><span>Note</span></div><p class="">The <a href="#active-source-buffer-changes">Changes to selected/enabled track state</a> section describes how this attribute gets
+            updated.</p></div>
+        </dd><dt><dfn data-dfn-for="" data-dfn-type="dfn" id="dom-readystate" data-idl="" data-title="readyState"><code>readyState</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-mediasource-readystate" class="internalDFN" data-link-type="dfn">ReadyState</a></span>, readonly       </dt><dd>
           <p>Indicates the current state of the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object. When the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> is created <code><a href="#dom-readystate">readyState</a></code> <em class="rfc2119" title="MUST">MUST</em> be set to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.
-          </p>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-duration" data-idl=""><code>duration</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span></dt>
-        <dd>
+        </p></dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-duration" data-idl="" data-title="duration"><code>duration</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span></dt><dd>
           <p>Allows the web application to set the presentation duration. The duration is initially set to NaN when the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object is created.</p>
           <p>On getting, run the following steps:</p>
           <ol>
@@ -1508,72 +1317,36 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>If the <code><a href="#dom-readystate">readyState</a></code> attribute is not <code><a href="#idl-def-ReadyState.open">"open"</a></code> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true on any <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the value being assigned to this attribute.
-              <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note8"><span>Note</span></div>
-                <p class="">The <a href="#duration-change-algorithm">duration change algorithm</a> will adjust <var>new duration</var> higher if there is any currently buffered coded frame with a higher end time.</p>
-              </div>
-              <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note9"><span>Note</span></div>
-                <p class=""><code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> and <code><a href="#dom-mediasource-endofstream">endOfStream()</a></code> can update the duration under certain circumstances.</p>
-              </div>
+              <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="4"><span>Note</span></div><p class="">The <a href="#duration-change-algorithm">duration change algorithm</a> will adjust <var>new duration</var> higher if there is any currently buffered coded frame with a higher end time.</p></div>
+              <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="4"><span>Note</span></div><p class=""><code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> and <code><a href="#dom-mediasource-endofstream">endOfStream()</a></code> can update the duration under certain circumstances.</p></div>
             </li>
           </ol>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-onsourceopen" data-idl=""><code>onsourceopen</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-onsourceopen" data-idl="" data-title="onsourceopen"><code>onsourceopen</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-sourceopen">sourceopen</a></code> event.</p>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-onsourceended" data-idl=""><code>onsourceended</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-onsourceended" data-idl="" data-title="onsourceended"><code>onsourceended</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-sourceended">sourceended</a></code> event.</p>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-onsourceclose" data-idl=""><code>onsourceclose</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-onsourceclose" data-idl="" data-title="onsourceclose"><code>onsourceclose</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-sourceclose">sourceclose</a></code> event.</p>
-        </dd>
-      </dl>
-    </section>
-
-    <section id="methods" typeof="bibo:Chapter" resource="#methods" property="bibo:hasPart">
-      <h3 id="h-methods" resource="#h-methods"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2 </span>Methods</span>
-      </h3>
-      <dl class="methods" data-dfn-for="MediaSource" data-link-for="MediaSource"><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-addsourcebuffer" data-idl=""><code>addSourceBuffer</code></dfn></dt>
-        <dd>
+        </dd></dl></section><section id="methods"><h3 id="x2-2-methods"><span class="secno">2.2 </span>Methods</h3><dl class="methods" data-dfn-for="MediaSource" data-link-for="MediaSource"><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-addsourcebuffer" data-idl="" data-title="addSourceBuffer" data-lt="addSourceBuffer|addsourcebuffer()"><code>addSourceBuffer</code></dfn></dt><dd>
           <p>Adds a new <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</p>
-
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">type</td>
-                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">type</td><td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If <var>type</var> is an empty string then throw a <code>TypeError</code> exception and abort these steps.</li>
             <li>If <var>type</var> contains a MIME type that is not supported or contains a MIME type that is not supported with the types specified for the other <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>, then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#notsupportederror">NotSupportedError</a></code> exception and abort these steps.</li>
-            <li>If the user agent can't handle any more SourceBuffer objects or if creating a SourceBuffer based on <var>type</var> would result in an unsupported <a href="#sourcebuffer-configuration">SourceBuffer configuration</a>, then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#quotaexceedederror">QuotaExceededError</a></code> exception and abort these steps.
-              <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note10"><span>Note</span></div>
-                <p class="">For example, a user agent <em class="rfc2119" title="MAY">MAY</em> throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#quotaexceedederror">QuotaExceededError</a></code> exception if the media element has reached the
-                  <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code> readyState. This can occur if the user agent's media engine does not support adding more tracks during playback.
-                </p>
-              </div>
+            <li>If the user agent can't handle any more SourceBuffer objects or if creating a SourceBuffer
+              based on <var>type</var> would result in an unsupported <a href="#sourcebuffer-configuration">SourceBuffer configuration</a>,
+              then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#quotaexceedederror">QuotaExceededError</a></code> exception and abort these steps.
+              <div class="note" id="issue-container-generatedID-8"><div role="heading" class="note-title marker" id="h-note-8" aria-level="4"><span>Note</span></div><p class="">For example, a user agent <em class="rfc2119" title="MAY">MAY</em> throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#quotaexceedederror">QuotaExceededError</a></code> exception if the media element has reached the
+                <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code> readyState. This can occur if the user agent's media engine does not support adding more tracks during
+                playback.
+              </p></div>
             </li>
             <li>If the <code><a href="#dom-readystate">readyState</a></code> attribute is not in the <code><a href="#idl-def-ReadyState.open">"open"</a></code> state then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>Create a new <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object and associated resources.</li>
-            <li>Set the <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> on the new object to the value in the "Generate Timestamps Flag" column of the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] entry that is associated with <var>type</var>.
-            </li>
-            <li>
+            <li>Set the <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> on the new object to the value in the
+               "Generate Timestamps Flag" column of the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] entry
+              that is associated with <var>type</var>.
+            </li><li>
               <dl class="switch">
                 <dt>If the <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true:</dt>
                 <dd>
@@ -1589,33 +1362,11 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             </li>
             <li>Add the new object to <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> and <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
             <li>Return the new object.</li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-removesourcebuffer" data-idl=""><code>removeSourceBuffer</code></dfn></dt>
-        <dd>
+          </ol></dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-removesourcebuffer" data-idl="" data-title="removeSourceBuffer" data-lt="removeSourceBuffer|removesourcebuffer()"><code>removeSourceBuffer</code></dfn></dt><dd>
           <p>Removes a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> from <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</p>
 
-
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">sourceBuffer</td>
-                <td class="prmType"><code>SourceBuffer</code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">sourceBuffer</td><td class="prmType"><code>SourceBuffer</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If <var>sourceBuffer</var> specifies an object that is not in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#notfounderror">NotFoundError</a></code> exception and abort these steps.</li>
             <li>If the <var>sourceBuffer</var>.<code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then run the following steps:
               <ol>
@@ -1634,20 +1385,16 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <ol>
                     <li>Set the <code><a href="#dom-audiotrack-sourcebuffer">sourceBuffer</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object to null.</li>
                     <li>Remove the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object from the <var>HTMLMediaElement audioTracks list</var>.
-                      <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note11"><span>Note</span></div>
-                        <p class="">
-                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object, at the <var>HTMLMediaElement audioTracks list</var>. If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>HTMLMediaElement audioTracks list</var>
-                        </p>
-                      </div>
+                    <div class="note" id="issue-container-generatedID-9"><div role="heading" class="note-title marker" id="h-note-9" aria-level="4"><span>Note</span></div><p class="">
+                      This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object, at the <var>HTMLMediaElement audioTracks list</var>.
+                      If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>HTMLMediaElement audioTracks list</var>
+                    </p></div>
                     </li>
                     <li>Remove the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object from the <var>SourceBuffer audioTracks list</var>.
-                      <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note12"><span>Note</span></div>
-                        <p class="">
-                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object, at the <var>SourceBuffer audioTracks list</var>. If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>SourceBuffer audioTracks list</var>
-                        </p>
-                      </div>
+                    <div class="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="4"><span>Note</span></div><p class="">
+                      This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object, at the <var>SourceBuffer audioTracks list</var>.
+                      If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>SourceBuffer audioTracks list</var>
+                    </p></div>
                     </li>
                   </ol>
                 </li>
@@ -1662,20 +1409,16 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <ol>
                     <li>Set the <code><a href="#dom-videotrack-sourcebuffer">sourceBuffer</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object to null.</li>
                     <li>Remove the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object from the <var>HTMLMediaElement videoTracks list</var>.
-                      <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note13"><span>Note</span></div>
-                        <p class="">
-                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object, at the <var>HTMLMediaElement videoTracks list</var>. If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>HTMLMediaElement videoTracks list</var>
-                        </p>
-                      </div>
+                    <div class="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="4"><span>Note</span></div><p class="">
+                      This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object, at the <var>HTMLMediaElement videoTracks list</var>.
+                      If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>HTMLMediaElement videoTracks list</var>
+                    </p></div>
                     </li>
                     <li>Remove the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object from the <var>SourceBuffer videoTracks list</var>.
-                      <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note14"><span>Note</span></div>
-                        <p class="">
-                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object, at the <var>SourceBuffer videoTracks list</var>. If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>SourceBuffer videoTracks list</var>
-                        </p>
-                      </div>
+                    <div class="note" id="issue-container-generatedID-12"><div role="heading" class="note-title marker" id="h-note-12" aria-level="4"><span>Note</span></div><p class="">
+                      This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object, at the <var>SourceBuffer videoTracks list</var>.
+                      If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object was true at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onchange">change</a></code> at the <var>SourceBuffer videoTracks list</var>
+                    </p></div>
                     </li>
                   </ol>
                 </li>
@@ -1691,20 +1434,16 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <ol>
                     <li>Set the <code><a href="#dom-texttrack-sourcebuffer">sourceBuffer</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object to null.</li>
                     <li>Remove the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object from the <var>HTMLMediaElement textTracks list</var>.
-                      <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note15"><span>Note</span></div>
-                        <p class="">
-                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object, at the <var>HTMLMediaElement textTracks list</var>. If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object was <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onchange">change</a></code> at the <var>HTMLMediaElement textTracks list</var>.
-                        </p>
-                      </div>
+                    <div class="note" id="issue-container-generatedID-13"><div role="heading" class="note-title marker" id="h-note-13" aria-level="4"><span>Note</span></div><p class="">
+                      This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object, at the <var>HTMLMediaElement textTracks list</var>.
+                      If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object was <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onchange">change</a></code> at the <var>HTMLMediaElement textTracks list</var>.
+                    </p></div>
                     </li>
                     <li>Remove the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object from the <var>SourceBuffer textTracks list</var>.
-                      <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note16"><span>Note</span></div>
-                        <p class="">
-                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object, at the <var>SourceBuffer textTracks list</var>. If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object was <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onchange">change</a></code> at the <var>SourceBuffer textTracks list</var>.
-                        </p>
-                      </div>
+                    <div class="note" id="issue-container-generatedID-14"><div role="heading" class="note-title marker" id="h-note-14" aria-level="4"><span>Note</span></div><p class="">
+                      This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onremovetrack">removetrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object, at the <var>SourceBuffer textTracks list</var>.
+                      If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a></code> attribute on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object was <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> at the beginning of this removal step, then this should also trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onchange">change</a></code> at the <var>SourceBuffer textTracks list</var>.
+                    </p></div>
                     </li>
                   </ol>
                 </li>
@@ -1713,44 +1452,21 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
 
             <li>If <var>sourceBuffer</var> is in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then remove <var>sourceBuffer</var> from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> and
               <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at the <a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a> returned by <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-            <li>Remove <var>sourceBuffer</var> from <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> and <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at the <a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a> returned by <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
+            <li>Remove <var>sourceBuffer</var> from <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> and <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at
+              the <a href="#idl-def-sourcebufferlist" class="internalDFN" data-link-type="dfn"><code>SourceBufferList</code></a> returned by <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
             <li>Destroy all resources for <var>sourceBuffer</var>.</li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-endofstream" data-idl=""><code>endOfStream</code></dfn></dt>
-        <dd>
+          </ol></dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-endofstream" data-idl="" data-title="endOfStream" data-lt="endOfStream|endofstream()"><code>endOfStream</code></dfn></dt><dd>
           <p>Signals the end of the stream.</p>
 
-
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">error</td>
-                <td class="prmType"><code>EndOfStreamError</code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">error</td><td class="prmType"><code>EndOfStreamError</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If the <code><a href="#dom-readystate">readyState</a></code> attribute is not in the <code><a href="#idl-def-ReadyState.open">"open"</a></code> state then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true on any <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>Run the <a href="#end-of-stream-algorithm">end of stream algorithm</a> with the <var>error</var> parameter set to <var>error</var>.</li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-setliveseekablerange" data-idl=""><code>setLiveSeekableRange</code></dfn></dt>
-        <dd>
+          </ol></dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-setliveseekablerange" data-idl="" data-title="setLiveSeekableRange" data-lt="setLiveSeekableRange|setliveseekablerange()"><code>setLiveSeekableRange</code></dfn></dt><dd>
 
           <p>Updates the <var><a href="#live-seekable-range">live seekable range</a></var> variable used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-seekable">HTMLMediaElement.seekable</a></code> behavior.</p>
-
+          
           <table class="parameters">
             <tbody>
               <tr>
@@ -1776,507 +1492,402 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
               </tr>
             </tbody>
           </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+        <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If the <code><a href="#dom-readystate">readyState</a></code> attribute is not <code><a href="#idl-def-ReadyState.open">"open"</a></code> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If <var>start</var> is negative or greater than <var>end</var>, then throw a <code>TypeError</code> exception and abort these steps.</li>
             <li>Set <var><a href="#live-seekable-range">live seekable range</a></var> to be a new <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a> containing a single range whose start position is <var>start</var> and end position is <var>end</var>.
-            </li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-clearliveseekablerange" data-idl=""><code>clearLiveSeekableRange</code></dfn></dt>
-        <dd>
+          </li></ol></dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-clearliveseekablerange" data-idl="" data-title="clearLiveSeekableRange" data-lt="clearLiveSeekableRange|clearliveseekablerange()"><code>clearLiveSeekableRange</code></dfn></dt><dd>
           <p>Updates the <var><a href="#live-seekable-range">live seekable range</a></var> variable used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-seekable">HTMLMediaElement.seekable</a></code> behavior.</p>
 
-
-          <div><em>No parameters.</em></div>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+        <div><em>No parameters.</em></div><div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If the <code><a href="#dom-readystate">readyState</a></code> attribute is not <code><a href="#idl-def-ReadyState.open">"open"</a></code> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If <var><a href="#live-seekable-range">live seekable range</a></var> contains a range, then set <var><a href="#live-seekable-range">live seekable range</a></var> to be a new empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object.
-            </li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-istypesupported" data-idl=""><code>isTypeSupported</code></dfn>, static</dt>
-        <dd>
+          </li></ol></dd><dt><dfn data-dfn-for="mediasource" data-dfn-type="dfn" id="dom-mediasource-istypesupported" data-idl="" data-title="isTypeSupported" data-lt="isTypeSupported|istypesupported()"><code>isTypeSupported</code></dfn>, static</dt><dd>
           <p>Check to see whether the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> is capable of creating <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects for the specified MIME type.</p>
 
-
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note17"><span>Note</span></div>
-            <p class="">
-              If true is returned from this method, it only indicates that the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> implementation is capable of creating <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects for the specified MIME type. An <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> call <em class="rfc2119" title="SHOULD">SHOULD</em> still fail if sufficient resources are not available to support the addition of a new <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.
-            </p>
-          </div>
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note18"><span>Note</span></div>
-            <p class="">
-              This method returning true implies that HTMLMediaElement.canPlayType() will return "maybe" or "probably" since it does not make sense for a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> to support a type the HTMLMediaElement knows it cannot play.
-            </p>
-          </div>
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">type</td>
-                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean" class="idlType">boolean</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+          <div class="note" id="issue-container-generatedID-15"><div role="heading" class="note-title marker" id="h-note-15" aria-level="4"><span>Note</span></div><p class="">
+            If true is returned from this method, it only indicates that the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> implementation is capable of creating <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects for the specified MIME type. An <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> call <em class="rfc2119" title="SHOULD">SHOULD</em> still fail if sufficient resources are not available to support the addition of a new <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.
+          </p></div>
+          <div class="note" id="issue-container-generatedID-16"><div role="heading" class="note-title marker" id="h-note-16" aria-level="4"><span>Note</span></div><p class="">
+            This method returning true implies that HTMLMediaElement.canPlayType() will return "maybe" or "probably" since it does not make sense for a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> to support a type the HTMLMediaElement knows it cannot play.
+          </p></div>
+        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">type</td><td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean" class="idlType">boolean</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If <var>type</var> is an empty string, then return false.</li>
             <li>If <var>type</var> does not contain a valid MIME type string, then return false.</li>
             <li>If <var>type</var> contains a media type or media subtype that the MediaSource does not support, then return false.</li>
             <li>If <var>type</var> contains a codec that the MediaSource does not support, then return false.</li>
             <li>If the MediaSource does not support the specified combination of media type, media subtype, and codecs then return false.</li>
             <li>Return true.</li>
+          </ol></dd></dl>
+      </section>
+
+      <section id="mediasource-events">
+        <h3 id="x2-3-event-summary"><span class="secno">2.3 </span>Event Summary</h3>
+        <table class="old-table">
+          <thead>
+            <tr>
+              <th>Event name</th>
+              <th>Interface</th>
+              <th>Dispatched when...</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><dfn id="dom-evt-sourceopen"><code>sourceopen</code></dfn></td>
+              <td><code>Event</code></td>
+              <td><code><a href="#dom-readystate">readyState</a></code> transitions from <code><a href="#idl-def-ReadyState.closed">"closed"</a></code> to <code><a href="#idl-def-ReadyState.open">"open"</a></code> or from <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> to <code><a href="#idl-def-ReadyState.open">"open"</a></code>.</td>
+            </tr>
+            <tr>
+              <td><dfn id="dom-evt-sourceended"><code>sourceended</code></dfn></td>
+              <td><code>Event</code></td>
+              <td><code><a href="#dom-readystate">readyState</a></code> transitions from <code><a href="#idl-def-ReadyState.open">"open"</a></code> to <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>.</td>
+            </tr>
+            <tr>
+              <td><dfn id="dom-evt-sourceclose"><code>sourceclose</code></dfn></td>
+              <td><code>Event</code></td>
+              <td><code><a href="#dom-readystate">readyState</a></code> transitions from <code><a href="#idl-def-ReadyState.open">"open"</a></code> to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code> or <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="mediasource-algorithms">
+        <h3 id="x2-4-algorithms"><span class="secno">2.4 </span>Algorithms</h3>
+
+        <section id="mediasource-attach">
+          <h4 id="x2-4-1-attaching-to-a-media-element"><span class="secno">2.4.1 </span>Attaching to a media element</h4>
+          <p> A <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object can be attached to a media element by assigning a <a href="#mediasource-object-url">MediaSource object URL</a> to the media element <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#element-attrdef-media-src">src</a></code> attribute or the src attribute of a &lt;source&gt; inside a media element. A <a href="#mediasource-object-url">MediaSource object URL</a> is created by passing a MediaSource object to <code><a href="#dom-url-createobjecturl">createObjectURL()</a></code>.</p>
+
+          <p>If the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> was invoked with
+          a media provider object that is a MediaSource object or a URL record whose object is a MediaSource object,
+          then let mode be local, skip the first step in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>
+          (which may otherwise set mode to remote) and add the steps and clarifications below to the <span>"<i>Otherwise (mode is local)</i>"</span> section of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>.
+          </p><div class="note" id="issue-container-generatedID-17"><div role="heading" class="note-title marker" id="h-note-17" aria-level="5"><span>Note</span></div><p class="">The <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s first step is expected to eventually align with selecting local mode for URL records whose objects are media provider objects. The intent is that if the HTMLMediaElement's <code>src</code> attribute or selected child <code>&lt;source&gt;</code>'s <code>src</code> attribute is a <code>blob:</code> URL matching a <a href="#mediasource-object-url">MediaSource object URL</a> when the respective <code>src</code> attribute was last changed, then that MediaSource object is used as the media provider object and current media resource in the local mode logic in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>. This also means that the remote mode logic that includes observance of any preload attribute is skipped when a MediaSource object is attached. Even with that eventual change to [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>], the execution of the following steps at the beginning of the local mode logic is still required when the current media resource is a MediaSource object.</p></div>
+          <div class="note" id="issue-container-generatedID-18"><div role="heading" class="note-title marker" id="h-note-18" aria-level="5"><span>Note</span></div><p class="">Relative to the action which triggered the media element's resource selection algorithm, these steps are asynchronous. The resource fetch algorithm is run after the task that invoked the resource selection algorithm is allowed to continue and a stable state is reached. Implementations may delay the steps in the "<i>Otherwise</i>" clause, below, until the MediaSource object is ready for use.</p></div>
+          <dl class="switch">
+            <dt>If <code><a href="#dom-readystate">readyState</a></code> is NOT set to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code></dt>
+            <dd>Run the <span>"<i>If the media data cannot be fetched at all, due to network errors, causing the user agent to give up trying to fetch the resource</i>"</span> steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
+            <dt>Otherwise</dt>
+            <dd>
+              <ol>
+                <li>Set the media element's <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#delaying-the-load-event-flag">delaying-the-load-event-flag</a> to false.</li>
+                <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute to <code><a href="#idl-def-ReadyState.open">"open"</a></code>.</li>
+                <li>
+                  <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceopen">sourceopen</a></code> at the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>.</li>
+                <li>Continue the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> by running the remaining <span>"<i>Otherwise (mode is local)</i>"</span> steps, with these clarifications:
+                  <ol>
+                    <li>Text in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> or the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a> that refers to "the download", "bytes received", or "whenever new data for the current media resource becomes available" refers to data passed in via <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code>.</li>
+                    <li>References to HTTP in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> and the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a> do not apply because the HTMLMediaElement does not fetch media data via HTTP when a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> is attached.</li>
+                  </ol>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+          <div class="note" id="issue-container-generatedID-19"><div role="heading" class="note-title marker" id="h-note-19" aria-level="5"><span>Note</span></div><p class="">An attached MediaSource does not use the remote mode steps in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>, so the media element will not fire "suspend" events. Though future versions of this specification will likely remove "progress" and "stalled" events from a media element with an attached MediaSource, user agents conforming to this version of the specification may still fire these two events as these [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] references changed after implementations of this specification stabilized.</p></div>
+        </section>
+
+        <section id="mediasource-detach">
+          <h4 id="x2-4-2-detaching-from-a-media-element"><span class="secno">2.4.2 </span>Detaching from a media element</h4>
+          <p>The following steps are run in any case where the media element is going to transition to <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-network_empty">NETWORK_EMPTY</a> and <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#eventdef-media-emptied">emptied</a> at the media element. These steps <em class="rfc2119" title="SHOULD">SHOULD</em> be run right before the transition.</p>
+
+          <ol>
+            <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.</li>
+            <li>Update <code><a href="#dom-mediasource-duration">duration</a></code> to NaN.</li>
+            <li>Remove all the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
+            <li>
+              <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
+            <li>Remove all the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects from <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
+            <li>
+              <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
+            <li>
+              <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceclose">sourceclose</a></code> at the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>.</li>
           </ol>
-        </dd>
-      </dl>
-    </section>
+          <div class="note" id="issue-container-generatedID-20"><div role="heading" class="note-title marker" id="h-note-20" aria-level="5"><span>Note</span></div><p class="">Going forward, this algorithm is intended to be externally called and run in any case where the attached <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>, if any, must be detached from the media element.  It <em class="rfc2119" title="MAY">MAY</em> be called on HTMLMediaElement [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] operations like load() and resource fetch algorithm failures in addition to, or in place of, when the media element transitions to <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-network_empty">NETWORK_EMPTY</a>. Resource fetch algorithm failures are those which abort either the resource fetch algorithm or the resource selection algorithm, with the exception that the "Final step" [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] is not considered a failure that triggers detachment.</p></div>
+        </section>
 
-    <section id="mediasource-events" typeof="bibo:Chapter" resource="#mediasource-events" property="bibo:hasPart">
-      <h3 id="h-mediasource-events" resource="#h-mediasource-events"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3 </span>Event Summary</span>
-      </h3>
-      <table class="old-table">
-        <thead>
-          <tr>
-            <th>Event name</th>
-            <th>Interface</th>
-            <th>Dispatched when...</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><dfn id="dom-evt-sourceopen"><code>sourceopen</code></dfn></td>
-            <td><code>Event</code></td>
-            <td><code><a href="#dom-readystate">readyState</a></code> transitions from <code><a href="#idl-def-ReadyState.closed">"closed"</a></code> to <code><a href="#idl-def-ReadyState.open">"open"</a></code> or from <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> to <code><a href="#idl-def-ReadyState.open">"open"</a></code>.</td>
-          </tr>
-          <tr>
-            <td><dfn id="dom-evt-sourceended"><code>sourceended</code></dfn></td>
-            <td><code>Event</code></td>
-            <td><code><a href="#dom-readystate">readyState</a></code> transitions from <code><a href="#idl-def-ReadyState.open">"open"</a></code> to <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>.</td>
-          </tr>
-          <tr>
-            <td><dfn id="dom-evt-sourceclose"><code>sourceclose</code></dfn></td>
-            <td><code>Event</code></td>
-            <td><code><a href="#dom-readystate">readyState</a></code> transitions from <code><a href="#idl-def-ReadyState.open">"open"</a></code> to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code> or <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+        <section id="mediasource-seeking">
+          <h4 id="x2-4-3-seeking"><span class="secno">2.4.3 </span>Seeking</h4>
+          <p>Run the following steps as part of the "<i>Wait until the user agent has established whether or not the media data for the new playback position is available, and, if it is, until it has decoded enough data to play back that position"</i> step of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#seek">seek algorithm</a>:</p>
+          <ol>
+            <li>
+            <div class="note" id="issue-container-generatedID-21"><div role="heading" class="note-title marker" id="h-note-21" aria-level="5"><span>Note</span></div><p class="">The media element looks for <a href="#media-segment">media segments</a> containing the <var>new playback position</var> in each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.
+            Any position within a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> in the current value of the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute has all necessary media segments buffered for that position.</p></div>
+              <dl class="switch">
+                <dt>If <var>new playback position</var> is not in any <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code></dt>
+                  <dd>
+                  <ol>
+                    <li>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than
+                      <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute
+                      to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
+                    <div class="note" id="issue-container-generatedID-22"><div role="heading" class="note-title marker" id="h-note-22" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+                    </li>
+                    <li>The media element waits until an <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> call causes the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> to set
+                      the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to a value greater than <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
+                      <div class="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>Note</span></div><p class="">The web application can use <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> and <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to determine what the media element needs to resume playback.</p></div>
+                    </li>
+                  </ol>
+                </dd>
+                <dt>Otherwise</dt>
+                <dd>Continue
+                <div class="note" id="issue-container-generatedID-24"><div role="heading" class="note-title marker" id="h-note-24" aria-level="5"><span>Note</span></div><p class="">If the <code><a href="#dom-readystate">readyState</a></code> attribute is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> and the <var>new playback position</var> is within a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> currently in <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code>, then the seek operation must continue to completion here even if one or more currently selected or enabled track buffers' largest range end timestamp is less than <var>new playback position</var>. This condition should only occur due to logic in <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> when <code><a href="#dom-readystate">readyState</a></code> is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>.</p></div>
+                </dd>
+              </dl>
+            </li>
+            <li>The media element resets all decoders and initializes each one with data from the appropriate <a href="#init-segment">initialization segment</a>.</li>
+            <li>The media element feeds <a href="#coded-frame">coded frames</a> from the <a href="#active-track-buffers">active track buffers</a> into the decoders starting with the
+              closest <a href="#random-access-point">random access point</a> before the <var>new playback position</var>.</li>
+            <li>Resume the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#seek">seek algorithm</a> at the "<i>Await a stable state</i>" step.</li>
+          </ol>
+        </section>
 
-    <section id="mediasource-algorithms" typeof="bibo:Chapter" resource="#mediasource-algorithms" property="bibo:hasPart">
-      <h3 id="h-mediasource-algorithms" resource="#h-mediasource-algorithms"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4 </span>Algorithms</span>
-      </h3>
+        <section id="buffer-monitoring">
+          <h4 id="x2-4-4-sourcebuffer-monitoring"><span class="secno">2.4.4 </span>SourceBuffer Monitoring</h4>
+          <p>The following steps are periodically run during playback to make sure that all of the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> have <a href="#enough-data">enough data to ensure uninterrupted playback</a>. Changes to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> also cause these steps to run because they affect the conditions that trigger state transitions.</p>
 
-      <section id="mediasource-attach" typeof="bibo:Chapter" resource="#mediasource-attach" property="bibo:hasPart">
-        <h4 id="h-mediasource-attach" resource="#h-mediasource-attach"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.1 </span>Attaching to a media element</span>
-        </h4>
-        <p> A <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> object can be attached to a media element by assigning a <a href="#mediasource-object-url">MediaSource object URL</a> to the media element <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#element-attrdef-media-src">src</a></code> attribute or the src attribute of a &lt;source&gt; inside a media element. A <a href="#mediasource-object-url">MediaSource object URL</a> is created by passing a MediaSource object to <code><a href="#dom-url-createobjecturl">createObjectURL()</a></code>.</p>
+          <p>Having <dfn id="enough-data" data-dfn-type="dfn">enough data to ensure uninterrupted playback</dfn> is an implementation specific condition where the user agent
+          determines that it currently has enough data to play the presentation without stalling for a meaningful period of time. This condition is
+          constantly evaluated to determine when to transition the media element into and out of the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code> ready state.
+          These transitions indicate when the user agent believes it has enough data buffered or it needs more data respectively.</p>
 
-        <p>If the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> was invoked with a media provider object that is a MediaSource object or a URL record whose object is a MediaSource object, then let mode be local, skip the first step in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> (which may otherwise set mode to remote) and add the steps and clarifications below to the <span>"<i>Otherwise (mode is local)</i>"</span> section of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>.
-        </p>
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note19"><span>Note</span></div>
-          <p class="">The <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s first step is expected to eventually align with selecting local mode for URL records whose objects are media provider objects. The intent is that if the HTMLMediaElement's <code>src</code> attribute or selected child <code>&lt;source&gt;</code>'s <code>src</code> attribute is a <code>blob:</code> URL matching a <a href="#mediasource-object-url">MediaSource object URL</a> when the respective <code>src</code> attribute was last changed, then that MediaSource object is used as the media provider object and current media resource in the local mode logic in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>. This also means that the remote mode logic that includes observance of any preload attribute is skipped when a MediaSource object is attached. Even with that eventual change to [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>], the execution of the following steps at the beginning of the local mode logic is still required when the current media resource is a MediaSource object.</p>
-        </div>
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note20"><span>Note</span></div>
-          <p class="">Relative to the action which triggered the media element's resource selection algorithm, these steps are asynchronous. The resource fetch algorithm is run after the task that invoked the resource selection algorithm is allowed to continue and a stable state is reached. Implementations may delay the steps in the "<i>Otherwise</i>" clause, below, until the MediaSource object is ready for use.</p>
-        </div>
-        <dl class="switch">
-          <dt>If <code><a href="#dom-readystate">readyState</a></code> is NOT set to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code></dt>
-          <dd>Run the <span>"<i>If the media data cannot be fetched at all, due to network errors, causing the user agent to give up trying to fetch the resource</i>"</span> steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
-          <dt>Otherwise</dt>
-          <dd>
-            <ol>
-              <li>Set the media element's <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#delaying-the-load-event-flag">delaying-the-load-event-flag</a> to false.</li>
-              <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute to <code><a href="#idl-def-ReadyState.open">"open"</a></code>.</li>
-              <li>
-                <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceopen">sourceopen</a></code> at the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>.</li>
-              <li>Continue the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> by running the remaining <span>"<i>Otherwise (mode is local)</i>"</span> steps, with these clarifications:
-                <ol>
-                  <li>Text in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> or the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a> that refers to "the download", "bytes received", or "whenever new data for the current media resource becomes available" refers to data passed in via <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code>.</li>
-                  <li>References to HTTP in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a> and the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a> do not apply because the HTMLMediaElement does not fetch media data via HTTP when a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> is attached.</li>
-                </ol>
-              </li>
-            </ol>
-          </dd>
-        </dl>
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note21"><span>Note</span></div>
-          <p class="">An attached MediaSource does not use the remote mode steps in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>, so the media element will not fire "suspend" events. Though future versions of this specification will likely remove "progress" and "stalled" events from a media element with an attached MediaSource, user agents conforming to this version of the specification may still fire these two events as these [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] references changed after implementations of this specification stabilized.</p>
-        </div>
-      </section>
+          <div class="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>Note</span></div><p class="">An implementation <em class="rfc2119" title="MAY">MAY</em> choose to use bytes buffered, time buffered, the append rate, or any other metric it sees fit to
+            determine when it has enough data. The metrics used <em class="rfc2119" title="MAY">MAY</em> change during playback so web applications <em class="rfc2119" title="SHOULD">SHOULD</em> only rely on the value of
+            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> to determine whether more data is needed or not.</p></div>
 
-      <section id="mediasource-detach" typeof="bibo:Chapter" resource="#mediasource-detach" property="bibo:hasPart">
-        <h4 id="h-mediasource-detach" resource="#h-mediasource-detach"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.2 </span>Detaching from a media element</span>
-        </h4>
-        <p>The following steps are run in any case where the media element is going to transition to <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-network_empty">NETWORK_EMPTY</a> and <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#eventdef-media-emptied">emptied</a> at the media element. These steps <em class="rfc2119" title="SHOULD">SHOULD</em> be run right before the transition.</p>
+          <div class="note" id="issue-container-generatedID-26"><div role="heading" class="note-title marker" id="h-note-26" aria-level="5"><span>Note</span></div><p class="">When the media element needs more data, the user agent <em class="rfc2119" title="SHOULD">SHOULD</em> transition it from <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code> to
+            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code> early enough for a web application to be able to respond without causing an interruption in playback.
+            For example, transitioning when the current playback position is 500ms before the end of the buffered data gives the application roughly
+            500ms to append more data before playback stalls.</p></div>
 
-        <ol>
-          <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.</li>
-          <li>Update <code><a href="#dom-mediasource-duration">duration</a></code> to NaN.</li>
-          <li>Remove all the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-          <li>
-            <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-          <li>Remove all the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects from <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
-          <li>
-            <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
-          <li>
-            <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceclose">sourceclose</a></code> at the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>.</li>
-        </ol>
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note22"><span>Note</span></div>
-          <p class="">Going forward, this algorithm is intended to be externally called and run in any case where the attached <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>, if any, must be detached from the media element. It <em class="rfc2119" title="MAY">MAY</em> be called on HTMLMediaElement [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] operations like load() and resource fetch algorithm failures in addition to, or in place of, when the media element transitions to <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-network_empty">NETWORK_EMPTY</a>. Resource fetch algorithm failures are those which abort either the resource fetch algorithm or the resource selection algorithm, with the exception that the "Final step" [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] is not considered a failure that triggers detachment.</p>
-        </div>
-      </section>
+          <dl class="switch">
+            <dt>If the the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>:</dt>
+            <dd>
+              <ol>
+                <li>Abort these steps.</li>
+              </ol>
+            </dd>
+            <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> does not contain a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> for the current playback position:</dt>
+            <dd>
+              <ol>
+                <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
+                <div class="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div></li>
+                <li>Abort these steps.</li>
+              </ol>
+            </dd>
+            <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and <a href="#enough-data">enough data to ensure uninterrupted playback</a>:</dt>
+            <dd>
+              <ol>
+                <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code>.
+                <div class="note" id="issue-container-generatedID-28"><div role="heading" class="note-title marker" id="h-note-28" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div></li>
+                <li>Playback may resume at this point if it was previously suspended by a transition to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.</li>
+                <li>Abort these steps.</li>
+              </ol>
+            </dd>
+            <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and some time beyond the current playback position, then run the following steps:</dt>
+            <dd>
+              <ol>
+                <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code>.
+                <div class="note" id="issue-container-generatedID-29"><div role="heading" class="note-title marker" id="h-note-29" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+                </li>
+                <li>Playback may resume at this point if it was previously suspended by a transition to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.</li>
+                <li>Abort these steps.</li>
+              </ol>
+            </dd>
+            <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that ends at the current playback position and does not have a range covering the time immediately after the current position:</dt>
+            <dd>
+              <ol>
+                <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.
+                <div class="note" id="issue-container-generatedID-30"><div role="heading" class="note-title marker" id="h-note-30" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+                </li>
+                <li>Playback is suspended at this point since the media element doesn't have enough data to advance the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-timeline">media timeline</a>.</li>
+                <li>Abort these steps.</li>
+              </ol>
+            </dd>
+          </dl>
+        </section>
 
-      <section id="mediasource-seeking" typeof="bibo:Chapter" resource="#mediasource-seeking" property="bibo:hasPart">
-        <h4 id="h-mediasource-seeking" resource="#h-mediasource-seeking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.3 </span>Seeking</span>
-        </h4>
-        <p>Run the following steps as part of the "<i>Wait until the user agent has established whether or not the media data for the new playback position is available, and, if it is, until it has decoded enough data to play back that position"</i> step of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#seek">seek algorithm</a>:</p>
-        <ol>
-          <li>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note23"><span>Note</span></div>
-              <p class="">The media element looks for <a href="#media-segment">media segments</a> containing the <var>new playback position</var> in each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>. Any position within a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> in the current value of the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute has all necessary media segments buffered for that position.</p>
-            </div>
-            <dl class="switch">
-              <dt>If <var>new playback position</var> is not in any <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code></dt>
-              <dd>
-                <ol>
-                  <li>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than
-                    <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
-                    <div class="note">
-                      <div class="note-title marker" aria-level="5" role="heading" id="h-note24"><span>Note</span></div>
-                      <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-                    </div>
-                  </li>
-                  <li>The media element waits until an <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> call causes the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> to set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to a value greater than <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
-                    <div class="note">
-                      <div class="note-title marker" aria-level="5" role="heading" id="h-note25"><span>Note</span></div>
-                      <p class="">The web application can use <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> and <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to determine what the media element needs to resume playback.</p>
-                    </div>
-                  </li>
-                </ol>
-              </dd>
-              <dt>Otherwise</dt>
-              <dd>Continue
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note26"><span>Note</span></div>
-                  <p class="">If the <code><a href="#dom-readystate">readyState</a></code> attribute is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> and the <var>new playback position</var> is within a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> currently in <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code>, then the seek operation must continue to completion here even if one or more currently selected or enabled track buffers' largest range end timestamp is less than <var>new playback position</var>. This condition should only occur due to logic in <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> when <code><a href="#dom-readystate">readyState</a></code> is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>.</p>
-                </div>
-              </dd>
-            </dl>
-          </li>
-          <li>The media element resets all decoders and initializes each one with data from the appropriate <a href="#init-segment">initialization segment</a>.</li>
-          <li>The media element feeds <a href="#coded-frame">coded frames</a> from the <a href="#active-track-buffers">active track buffers</a> into the decoders starting with the closest <a href="#random-access-point">random access point</a> before the <var>new playback position</var>.</li>
-          <li>Resume the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#seek">seek algorithm</a> at the "<i>Await a stable state</i>" step.</li>
-        </ol>
-      </section>
-
-      <section id="buffer-monitoring" typeof="bibo:Chapter" resource="#buffer-monitoring" property="bibo:hasPart">
-        <h4 id="h-buffer-monitoring" resource="#h-buffer-monitoring"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.4 </span>SourceBuffer Monitoring</span>
-        </h4>
-        <p>The following steps are periodically run during playback to make sure that all of the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> have <a href="#enough-data">enough data to ensure uninterrupted playback</a>. Changes to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> also cause these steps to run because they affect the conditions that trigger state transitions.</p>
-
-        <p>Having <dfn id="enough-data" data-dfn-type="dfn">enough data to ensure uninterrupted playback</dfn> is an implementation specific condition where the user agent determines that it currently has enough data to play the presentation without stalling for a meaningful period of time. This condition is constantly evaluated to determine when to transition the media element into and out of the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code> ready state. These transitions indicate when the user agent believes it has enough data buffered or it needs more data respectively.</p>
-
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note27"><span>Note</span></div>
-          <p class="">An implementation <em class="rfc2119" title="MAY">MAY</em> choose to use bytes buffered, time buffered, the append rate, or any other metric it sees fit to determine when it has enough data. The metrics used <em class="rfc2119" title="MAY">MAY</em> change during playback so web applications <em class="rfc2119" title="SHOULD">SHOULD</em> only rely on the value of
-            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> to determine whether more data is needed or not.</p>
-        </div>
-
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note28"><span>Note</span></div>
-          <p class="">When the media element needs more data, the user agent <em class="rfc2119" title="SHOULD">SHOULD</em> transition it from <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code> to
-            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code> early enough for a web application to be able to respond without causing an interruption in playback. For example, transitioning when the current playback position is 500ms before the end of the buffered data gives the application roughly 500ms to append more data before playback stalls.</p>
-        </div>
-
-        <dl class="switch">
-          <dt>If the the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>:</dt>
-          <dd>
-            <ol>
-              <li>Abort these steps.</li>
-            </ol>
-          </dd>
-          <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> does not contain a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> for the current playback position:</dt>
-          <dd>
-            <ol>
-              <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note29"><span>Note</span></div>
-                  <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-                </div>
-              </li>
-              <li>Abort these steps.</li>
-            </ol>
-          </dd>
-          <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and <a href="#enough-data">enough data to ensure uninterrupted playback</a>:</dt>
-          <dd>
-            <ol>
-              <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note30"><span>Note</span></div>
-                  <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-                </div>
-              </li>
-              <li>Playback may resume at this point if it was previously suspended by a transition to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.</li>
-              <li>Abort these steps.</li>
-            </ol>
-          </dd>
-          <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and some time beyond the current playback position, then run the following steps:</dt>
-          <dd>
-            <ol>
-              <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note31"><span>Note</span></div>
-                  <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-                </div>
-              </li>
-              <li>Playback may resume at this point if it was previously suspended by a transition to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.</li>
-              <li>Abort these steps.</li>
-            </ol>
-          </dd>
-          <dt>If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> contains a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that ends at the current playback position and does not have a range covering the time immediately after the current position:</dt>
-          <dd>
-            <ol>
-              <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note32"><span>Note</span></div>
-                  <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-                </div>
-              </li>
-              <li>Playback is suspended at this point since the media element doesn't have enough data to advance the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-timeline">media timeline</a>.</li>
-              <li>Abort these steps.</li>
-            </ol>
-          </dd>
-        </dl>
-      </section>
-
-      <section id="active-source-buffer-changes" typeof="bibo:Chapter" resource="#active-source-buffer-changes" property="bibo:hasPart">
-        <h4 id="h-active-source-buffer-changes" resource="#h-active-source-buffer-changes"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.5 </span>Changes to selected/enabled track state</span>
-        </h4>
-        <p>During playback <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> needs to be updated if the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected video track</a>, the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled audio track(s)</a>, or a text track <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a> changes. When one or more of these changes occur the following steps need to be followed.</p>
-        <dl class="switch">
-          <dt>If the selected video track changes, then run the following steps:</dt>
-          <dd>
-            <ol>
-              <li>If the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the previously selected video track is not associated with any other enabled tracks, run the following steps:
-                <ol>
-                  <li>Remove the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-                  <li>
-                    <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-                  </li>
-                </ol>
-              </li>
-              <li>If the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the newly selected video track is not already in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, run the following steps:
-                <ol>
-                  <li>Add the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-                  <li>
-                    <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </dd>
-          <dt>If an audio track becomes disabled and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not associated with any other enabled or selected track, then run the following steps:</dt>
-          <dd>
-            <ol>
-              <li>Remove the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the audio track from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-              <li>
-                <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-            </ol>
-          </dd>
-          <dt>If an audio track becomes enabled and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not already in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then run the following steps:
+        <section id="active-source-buffer-changes">
+          <h4 id="x2-4-5-changes-to-selected-enabled-track-state"><span class="secno">2.4.5 </span>Changes to selected/enabled track state</h4>
+          <p>During playback <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> needs to be updated if the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected video track</a>, the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled audio track(s)</a>, or a text track <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a> changes. When one or more of these changes occur the following steps need to be followed.</p>
+          <dl class="switch">
+            <dt>If the selected video track changes, then run the following steps:</dt>
+            <dd>
+              <ol>
+                <li>If the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the previously selected video track is not associated with any other enabled tracks, run the following steps:
+                  <ol>
+                    <li>Remove the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
+                    <li>
+                      <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                    </li>
+                  </ol>
+                </li>
+                <li>If the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the newly selected video track is not already in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, run the following steps:
+                  <ol>
+                    <li>Add the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
+                    <li>
+                      <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </dd>
+            <dt>If an audio track becomes disabled and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not associated with any other enabled or selected track, then run the following steps:</dt>
+            <dd>
+              <ol>
+                <li>Remove the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the audio track from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+                <li>
+                  <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+              </ol>
+            </dd>
+            <dt>If an audio track becomes enabled and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not already in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then run the following steps:
             </dt>
-          <dd>
-            <ol>
-              <li>Add the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the audio track to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-              <li>
-                <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-            </ol>
-          </dd>
-          <dt>If a text track <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a> becomes <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-disabled">"disabled"</a></code> and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not associated with any other enabled or selected track, then run the following steps:</dt>
-          <dd>
-            <ol>
-              <li>Remove the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the text track from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-              <li>
-                <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-            </ol>
-          </dd>
-          <dt>If a text track <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a> becomes <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not already in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then run the following steps:
+            <dd>
+              <ol>
+                <li>Add the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the audio track to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+                <li>
+                  <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+              </ol>
+            </dd>
+            <dt>If a text track <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a> becomes <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-disabled">"disabled"</a></code> and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not associated with any other enabled or selected track, then run the following steps:</dt>
+            <dd>
+              <ol>
+                <li>Remove the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the text track from <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+                <li>
+                  <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+              </ol>
+            </dd>
+            <dt>If a text track <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a> becomes <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code> and the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with this track is not already in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, then run the following steps:
             </dt>
-          <dd>
-            <ol>
-              <li>Add the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the text track to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-              <li>
-                <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
-              </li>
-            </ol>
-          </dd>
-        </dl>
-      </section>
+            <dd>
+              <ol>
+                <li>Add the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> associated with the text track to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+                <li>
+                  <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </section>
 
-      <section id="duration-change-algorithm" typeof="bibo:Chapter" resource="#duration-change-algorithm" property="bibo:hasPart">
-        <h4 id="h-duration-change-algorithm" resource="#h-duration-change-algorithm"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.6 </span>Duration change</span>
-        </h4>
-        <p>Follow these steps when <code><a href="#dom-mediasource-duration">duration</a></code> needs to change to a <var>new duration</var>.</p>
-        <ol>
-          <li>If the current value of <code><a href="#dom-mediasource-duration">duration</a></code> is equal to <var>new duration</var>, then return.</li>
-          <li>If <var>new duration</var> is less than the highest <a href="#presentation-timestamp">presentation timestamp</a> of any buffered <a href="#coded-frame">coded frames</a> for all <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note33"><span>Note</span></div>
-              <p class="">Duration reductions that would truncate currently buffered media are disallowed. When truncation is necessary, use <code><a href="#dom-sourcebuffer-remove">remove()</a></code> to reduce the buffered range before updating <code><a href="#dom-mediasource-duration">duration</a></code>.</p>
-            </div>
-          </li>
-          <li>Let <var>highest end time</var> be the largest <a href="#track-buffer-ranges">track buffer ranges</a> end time across all the <a href="#track-buffer">track buffers</a> across all <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
-          <li>If <var>new duration</var> is less than <var>highest end time</var>, then
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note34"><span>Note</span></div>
-              <p class="">This condition can occur because the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a> preserves coded frames that start before the start of the removal range.</p>
-            </div>
-            <ol>
+        <section id="duration-change-algorithm">
+          <h4 id="x2-4-6-duration-change"><span class="secno">2.4.6 </span>Duration change</h4>
+          <p>Follow these steps when <code><a href="#dom-mediasource-duration">duration</a></code> needs to change to a <var>new duration</var>.</p>
+          <ol>
+            <li>If the current value of <code><a href="#dom-mediasource-duration">duration</a></code> is equal to <var>new duration</var>, then return.</li>
+            <li>If <var>new duration</var> is less than the highest <a href="#presentation-timestamp">presentation timestamp</a> of any buffered <a href="#coded-frame">coded frames</a> for all <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.
+            <div class="note" id="issue-container-generatedID-31"><div role="heading" class="note-title marker" id="h-note-31" aria-level="5"><span>Note</span></div><p class="">Duration reductions that would truncate currently buffered media are disallowed. When truncation is necessary, use <code><a href="#dom-sourcebuffer-remove">remove()</a></code> to reduce the buffered range before updating <code><a href="#dom-mediasource-duration">duration</a></code>.</p></div>
+            </li>
+            <li>Let <var>highest end time</var> be the largest <a href="#track-buffer-ranges">track buffer ranges</a> end time across all the <a href="#track-buffer">track buffers</a> across all <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.</li>
+            <li>If <var>new duration</var> is less than <var>highest end time</var>, then
+              <div class="note" id="issue-container-generatedID-32"><div role="heading" class="note-title marker" id="h-note-32" aria-level="5"><span>Note</span></div><p class="">This condition can occur because the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a> preserves coded frames that start before the start of the removal range.</p></div>
+              <ol>
 
-              <li>Update <var>new duration</var> to equal <var>highest end time</var>.</li>
-            </ol>
-          </li>
-          <li>Update <code><a href="#dom-mediasource-duration">duration</a></code> to <var>new duration</var>.</li>
-          <li>Update the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-duration">media duration</a></code> to <var>new duration</var> and run the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#durationChange">HTMLMediaElement duration change algorithm</a>.</li>
-        </ol>
-      </section>
+                <li>Update <var>new duration</var> to equal <var>highest end time</var>.</li>
+              </ol>
+            </li>
+            <li>Update <code><a href="#dom-mediasource-duration">duration</a></code> to <var>new duration</var>.</li>
+            <li>Update the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-duration">media duration</a></code> to <var>new duration</var> and run the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#durationChange">HTMLMediaElement duration change algorithm</a>.</li>
+          </ol>
+        </section>
 
-      <section id="end-of-stream-algorithm" typeof="bibo:Chapter" resource="#end-of-stream-algorithm" property="bibo:hasPart">
-        <h4 id="h-end-of-stream-algorithm" resource="#h-end-of-stream-algorithm"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.7 </span>End of stream algorithm</span>
-        </h4>
-        <p>This algorithm gets called when the application signals the end of stream via an <code><a href="#dom-mediasource-endofstream">endOfStream()</a></code> call or an algorithm needs to signal a decode error. This algorithm takes an <var>error</var> parameter that indicates whether an error will be signalled.</p>
-        <ol>
-          <li>Change the <code><a href="#dom-readystate">readyState</a></code> attribute value to <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>.</li>
-          <li>
-            <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceended">sourceended</a></code> at the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>.</li>
-          <li>
-            <dl class="switch">
-              <dt>If <var>error</var> is not set</dt>
-              <dd>
-                <ol>
-                  <li>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the largest <a href="#track-buffer-ranges">track buffer ranges</a> end time across all the <a href="#track-buffer">track buffers</a> across all <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.
-                    <div class="note">
-                      <div class="note-title marker" aria-level="5" role="heading" id="h-note35"><span>Note</span></div>
-                      <p class="">This allows the duration to properly reflect the end of the appended media segments. For example, if the duration was explicitly set to 10 seconds and only media segments for 0 to 5 seconds were appended before endOfStream() was called, then the duration will get updated to 5 seconds.</p>
-                    </div>
-                  </li>
-                  <li>Notify the media element that it now has all of the media data.</li>
-                </ol>
-              </dd>
-              <dt>If <var>error</var> is set to <code><a href="#idl-def-EndOfStreamError.network">"network"</a></code>
+        <section id="end-of-stream-algorithm">
+          <h4 id="x2-4-7-end-of-stream-algorithm"><span class="secno">2.4.7 </span>End of stream algorithm</h4>
+          <p>This algorithm gets called when the application signals the end of stream via an <code><a href="#dom-mediasource-endofstream">endOfStream()</a></code> call or an algorithm needs to
+            signal a decode error. This algorithm takes an <var>error</var> parameter that indicates whether an error will be signalled.</p>
+          <ol>
+            <li>Change the <code><a href="#dom-readystate">readyState</a></code> attribute value to <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>.</li>
+            <li>
+              <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceended">sourceended</a></code> at the <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a>.</li>
+            <li><dl class="switch">
+                <dt>If <var>error</var> is not set</dt>
+                <dd>
+                  <ol>
+                    <li>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to
+                      the largest <a href="#track-buffer-ranges">track buffer ranges</a> end time across all the <a href="#track-buffer">track buffers</a> across all <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code>.
+                      <div class="note" id="issue-container-generatedID-33"><div role="heading" class="note-title marker" id="h-note-33" aria-level="5"><span>Note</span></div><p class="">This allows the duration to properly reflect the end of the appended media segments. For example, if the duration was explicitly set to 10 seconds and only media segments for 0 to 5 seconds were appended before endOfStream() was called, then the duration will get updated to 5 seconds.</p></div>
+                    </li>
+                    <li>Notify the media element that it now has all of the media data.</li>
+                  </ol>
+                </dd>
+                <dt>If <var>error</var> is set to <code><a href="#idl-def-EndOfStreamError.network">"network"</a></code>
                 </dt>
-              <dd>
-                <dl class="switch">
-                  <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
+                <dd>
+                  <dl class="switch">
+                    <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
                     </dt>
-                  <dd>Run the <span>"<i>If the media data cannot be fetched at all, due to network errors, causing the user agent to give up trying to fetch the resource</i>"</span> steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
-                  <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
+                    <dd>Run the <span>"<i>If the media data cannot be fetched at all, due to network errors, causing the user agent to give up trying to fetch the resource</i>"</span> steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
+                    <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
                     </dt>
-                  <dd>Run the "<i>If the connection is interrupted after some media data has been received, causing the user agent to give up trying to fetch the resource</i>" steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
-                </dl>
-              </dd>
-              <dt>If <var>error</var> is set to <code><a href="#idl-def-EndOfStreamError.decode">"decode"</a></code>
+                    <dd>Run the "<i>If the connection is interrupted after some media data has been received, causing the user agent to give up trying to fetch the resource</i>" steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
+                  </dl>
+                </dd>
+                <dt>If <var>error</var> is set to <code><a href="#idl-def-EndOfStreamError.decode">"decode"</a></code>
                 </dt>
-              <dd>
-                <dl class="switch">
-                  <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
+                <dd>
+                  <dl class="switch">
+                    <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
                     </dt>
-                  <dd>Run the "<i>If the media data can be fetched but is found by inspection to be in an unsupported format, or can otherwise not be rendered at all</i>" steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
-                  <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
+                    <dd>Run the "<i>If the media data can be fetched but is found by inspection to be in an unsupported format, or can otherwise not be rendered at all</i>" steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
+                    <dt>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>
                     </dt>
-                  <dd>Run the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#fatal-decode-error">media data is corrupted</a> steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
-                </dl>
-              </dd>
-            </dl>
-          </li>
-        </ol>
+                    <dd>Run the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#fatal-decode-error">media data is corrupted</a> steps of the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#resource-fetch-algorithm">resource fetch algorithm</a>'s <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data-processing-steps-list">media data processing steps list</a>.</dd>
+                  </dl>
+                </dd>
+              </dl>
+            </li>
+          </ol>
+        </section>
       </section>
     </section>
-  </section>
 
-  <section id="sourcebuffer" typeof="bibo:Chapter" resource="#sourcebuffer" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-sourcebuffer" resource="#h-sourcebuffer"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>SourceBuffer Object</span>
-    </h2>
+    <section id="sourcebuffer">
+      <!--OddPage--><h2 id="x3-sourcebuffer-object"><span class="secno">3. </span>SourceBuffer Object</h2>
 
 
-    <pre class="def idl"><span class="idlEnum" id="idl-def-appendmode" data-idl="" data-title="AppendMode">enum <span class="idlEnumID">AppendMode</span> {
-    "<a href="#dom-appendmode-segments" class="idlEnumItem">segments</a>",
-    "<a href="#dom-appendmode-sequence" class="idlEnumItem">sequence</a>"
-};</span></pre>
-    <table class="simple" data-dfn-for="AppendMode" data-link-for="AppendMode">
-      <tbody>
-        <tr>
-          <th colspan="2">Enumeration description</th>
-        </tr>
-        <tr>
-          <td><dfn data-dfn-for="appendmode" data-dfn-type="dfn" id="dom-appendmode-segments" data-idl=""><code id="idl-def-AppendMode.segments">segments</code></dfn></td>
-          <td>
-            <p>The timestamps in the media segment determine where the <a href="#coded-frame">coded frames</a> are placed in the presentation. Media segments can be appended in any order.</p>
-          </td>
-        </tr>
-        <tr>
-          <td><dfn data-dfn-for="appendmode" data-dfn-type="dfn" id="dom-appendmode-sequence" data-idl=""><code id="idl-def-AppendMode.sequence">sequence</code></dfn></td>
-          <td>
-            <p>Media segments will be treated as adjacent in time independent of the timestamps in the media segment. Coded frames in a new media segment will be placed immediately after the coded frames in the previous media segment. The <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> attribute will be updated if a new offset is needed to make the new media segments adjacent to the previous media segment. Setting the <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> attribute in <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> mode allows a media segment to be placed at a specific position in the timeline without any knowledge of the timestamps in the media segment.
-            </p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+<div><pre class="def idl"><span class="idlEnum" id="idl-def-appendmode" data-idl="" data-title="AppendMode">enum <span class="idlEnumID">AppendMode</span> {
+    <a href="#dom-appendmode-segments" class="idlEnumItem">"segments"</a>,
+    <a href="#dom-appendmode-sequence" class="idlEnumItem">"sequence"</a>
+};</span></pre></div><table class="simple" data-dfn-for="AppendMode" data-link-for="AppendMode"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn data-dfn-for="appendmode" data-dfn-type="dfn" id="dom-appendmode-segments" data-idl="" data-title="segments"><code id="idl-def-AppendMode.segments">segments</code></dfn></td><td>
+          <p>The timestamps in the media segment determine where the <a href="#coded-frame">coded frames</a> are placed in the presentation. Media segments can be appended in any order.</p>
+        </td></tr><tr><td><dfn data-dfn-for="appendmode" data-dfn-type="dfn" id="dom-appendmode-sequence" data-idl="" data-title="sequence"><code id="idl-def-AppendMode.sequence">sequence</code></dfn></td><td>
+          <p>Media segments will be treated as adjacent in time independent of the timestamps in the media segment. Coded frames in a new media segment will be placed immediately after the coded
+            frames in the previous media segment. The <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> attribute will be updated if a new offset is needed to make the new media segments adjacent to the previous media segment.
+            Setting the <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> attribute in <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> mode allows a media segment to be placed at a specific position in the timeline without any knowledge
+            of the timestamps in the media segment.
+          </p>
+        </td></tr></tbody></table>
 
-    <pre class="def idl"><span class="idlInterface" id="idl-def-sourcebuffer" data-idl="" data-title="SourceBuffer">interface <span class="idlInterfaceID">SourceBuffer</span> : <span class="idlSuperclass">EventTarget</span> {
-<span class="idlAttribute" id="idl-def-sourcebuffer-mode" data-idl="" data-title="mode" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><a href="#idl-def-appendmode" class="internalDFN" data-link-type="dfn"><code>AppendMode</code></a></span>          <span class="idlAttrName"><a data-lt="mode" href="#dom-sourcebuffer-mode" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>mode</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-updating" data-idl="" data-title="updating" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></code></span>             <span class="idlAttrName"><a data-lt="updating" href="#dom-sourcebuffer-updating" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>updating</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-buffered" data-idl="" data-title="buffered" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code></span>          <span class="idlAttrName"><a data-lt="buffered" href="#dom-sourcebuffer-buffered" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>buffered</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-timestampoffset" data-idl="" data-title="timestampOffset" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span>              <span class="idlAttrName"><a data-lt="timestampOffset" href="#dom-sourcebuffer-timestampoffset" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>timestampOffset</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-audiotracks" data-idl="" data-title="audioTracks" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code></span>      <span class="idlAttrName"><a data-lt="audioTracks" href="#dom-sourcebuffer-audiotracks" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>audioTracks</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-videotracks" data-idl="" data-title="videoTracks" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code></span>      <span class="idlAttrName"><a data-lt="videoTracks" href="#dom-sourcebuffer-videotracks" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>videoTracks</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-texttracks" data-idl="" data-title="textTracks" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code></span>       <span class="idlAttrName"><a data-lt="textTracks" href="#dom-sourcebuffer-texttracks" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>textTracks</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-appendwindowstart" data-idl="" data-title="appendWindowStart" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span>              <span class="idlAttrName"><a data-lt="appendWindowStart" href="#dom-sourcebuffer-appendwindowstart" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>appendWindowStart</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-appendwindowend" data-idl="" data-title="appendWindowEnd" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span> <span class="idlAttrName"><a data-lt="appendWindowEnd" href="#dom-sourcebuffer-appendwindowend" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>appendWindowEnd</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-onupdatestart" data-idl="" data-title="onupdatestart" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onupdatestart" href="#dom-sourcebuffer-onupdatestart" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>onupdatestart</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-onupdate" data-idl="" data-title="onupdate" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onupdate" href="#dom-sourcebuffer-onupdate" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>onupdate</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-onupdateend" data-idl="" data-title="onupdateend" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onupdateend" href="#dom-sourcebuffer-onupdateend" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>onupdateend</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-onerror" data-idl="" data-title="onerror" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onerror" href="#dom-sourcebuffer-onerror" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>onerror</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebuffer-onabort" data-idl="" data-title="onabort" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-lt="onabort" href="#dom-sourcebuffer-onabort" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>onabort</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-sourcebuffer-appendbuffer(buffersource)" data-idl="" data-title="appendBuffer" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-lt="appendBuffer" href="#dom-sourcebuffer-appendbuffer" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>appendBuffer</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#common-BufferSource">BufferSource</a></code></span> <span class="idlParamName">data</span></span>);</span>
-<span class="idlMethod" id="idl-def-sourcebuffer-abort()" data-idl="" data-title="abort" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-lt="abort" href="#dom-sourcebuffer-abort" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>abort</code></a></span>();</span>
-<span class="idlMethod" id="idl-def-sourcebuffer-remove(double,unrestricted_double)" data-idl="" data-title="remove" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-lt="remove" href="#dom-sourcebuffer-remove" class="internalDFN" data-link-type="dfn" data-for="SourceBuffer"><code>remove</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span> <span class="idlParamName">start</span></span>, <span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span> <span class="idlParamName">end</span></span>);</span>
-};</span></pre>
-
-    <section id="attributes-1" typeof="bibo:Chapter" resource="#attributes-1" property="bibo:hasPart">
-      <h3 id="h-attributes-1" resource="#h-attributes-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Attributes</span>
-      </h3>
-      <dl class="attributes" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer"><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-mode" data-idl=""><code>mode</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-appendmode" class="internalDFN" data-link-type="dfn"><code>AppendMode</code></a></span></dt>
+<div><pre class="def idl"><span class="idlInterface" id="idl-def-sourcebuffer" data-idl="" data-title="SourceBuffer">interface <span class="idlInterfaceID">SourceBuffer</span> : <span class="idlSuperclass">EventTarget</span> {
+<span class="idlAttribute" id="idl-def-sourcebuffer-mode" data-idl="" data-title="mode" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><a href="#idl-def-appendmode" class="internalDFN" data-link-type="dfn"><code>AppendMode</code></a></span>          <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-mode" class="internalDFN" data-link-type="dfn"><code>mode</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-updating" data-idl="" data-title="updating" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></code></span>             <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-updating" class="internalDFN" data-link-type="dfn"><code>updating</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-buffered" data-idl="" data-title="buffered" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code></span>          <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-buffered" class="internalDFN" data-link-type="dfn"><code>buffered</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-timestampoffset" data-idl="" data-title="timestampOffset" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span>              <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-timestampoffset" class="internalDFN" data-link-type="dfn"><code>timestampOffset</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-audiotracks" data-idl="" data-title="audioTracks" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code></span>      <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-audiotracks" class="internalDFN" data-link-type="dfn"><code>audioTracks</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-videotracks" data-idl="" data-title="videoTracks" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code></span>      <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-videotracks" class="internalDFN" data-link-type="dfn"><code>videoTracks</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-texttracks" data-idl="" data-title="textTracks" data-dfn-for="sourcebuffer">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code></span>       <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-texttracks" class="internalDFN" data-link-type="dfn"><code>textTracks</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-appendwindowstart" data-idl="" data-title="appendWindowStart" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span>              <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-appendwindowstart" class="internalDFN" data-link-type="dfn"><code>appendWindowStart</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-appendwindowend" data-idl="" data-title="appendWindowEnd" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span> <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-appendwindowend" class="internalDFN" data-link-type="dfn"><code>appendWindowEnd</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-onupdatestart" data-idl="" data-title="onupdatestart" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-onupdatestart" class="internalDFN" data-link-type="dfn"><code>onupdatestart</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-onupdate" data-idl="" data-title="onupdate" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-onupdate" class="internalDFN" data-link-type="dfn"><code>onupdate</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-onupdateend" data-idl="" data-title="onupdateend" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-onupdateend" class="internalDFN" data-link-type="dfn"><code>onupdateend</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-onerror" data-idl="" data-title="onerror" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-onerror" class="internalDFN" data-link-type="dfn"><code>onerror</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebuffer-onabort" data-idl="" data-title="onabort" data-dfn-for="sourcebuffer">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>        <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="" href="#dom-sourcebuffer-onabort" class="internalDFN" data-link-type="dfn"><code>onabort</code></a></span>;</span>
+<span class="idlMethod" id="idl-def-sourcebuffer-appendbuffer-data" data-idl="" data-title="appendBuffer" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="appendBuffer|appendbuffer()" href="#dom-sourcebuffer-appendbuffer" class="internalDFN" data-link-type="dfn"><code>appendBuffer</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#common-BufferSource">BufferSource</a></code></span> <span class="idlParamName">data</span></span>);</span>
+<span class="idlMethod" id="idl-def-sourcebuffer-abort" data-idl="" data-title="abort" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="abort|abort()" href="#dom-sourcebuffer-abort" class="internalDFN" data-link-type="dfn"><code>abort</code></a></span>();</span>
+<span class="idlMethod" id="idl-def-sourcebuffer-changetype-type" data-idl="" data-title="changeType" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="changeType|changetype()" href="#dom-sourcebuffer-changetype" class="internalDFN" data-link-type="dfn"><code>changeType</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlParamName">type</span></span>);</span>
+<span class="idlMethod" id="idl-def-sourcebuffer-remove-start-end" data-idl="" data-title="remove" data-dfn-for="sourcebuffer">    <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void">void</a></code></span> <span class="idlMethName"><a data-no-default="" data-link-for="sourcebuffer" data-lt="remove|remove()" href="#dom-sourcebuffer-remove" class="internalDFN" data-link-type="dfn"><code>remove</code></a></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span> <span class="idlParamName">start</span></span>, <span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span> <span class="idlParamName">end</span></span>);</span>
+};</span></pre></div><section id="attributes-0"><h3 id="x3-1-attributes"><span class="secno">3.1 </span>Attributes</h3><dl class="attributes" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer">
+        <dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-mode" data-idl="" data-title="mode"><code>mode</code></dfn> of type <span class="idlAttrType"><a href="#idl-def-appendmode" class="internalDFN" data-link-type="dfn"><code>AppendMode</code></a></span></dt>
         <dd>
-          <p>Controls how a sequence of <a href="#media-segment">media segments</a> are handled. This attribute is initially set by <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> after the object is created.</p>
+          <p>Controls how a sequence of <a href="#media-segment">media segments</a> are handled. This attribute is initially set by <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> after the object is created, and can be updated by <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> or setting this attribute.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
           <ol>
@@ -2284,7 +1895,8 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>Let <var>new mode</var> equal the new value being assigned to this attribute.</li>
             <li>If <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true and <var>new mode</var> equals
-              <code><a href="#idl-def-AppendMode.segments">"segments"</a></code>, then throw a <code>TypeError</code> exception and abort these steps.</li>
+              <code><a href="#idl-def-AppendMode.segments">"segments"</a></code>, then throw a <code>TypeError</code>
+              exception and abort these steps.</li>
             <li>
               <p>If the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> is in the <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> state then run the following steps:</p>
               <ol>
@@ -2296,23 +1908,20 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>If the <var>new mode</var> equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>, then set the <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> to the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>.</li>
             <li>Update the attribute to <var>new mode</var>.</li>
           </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-updating" data-idl=""><code>updating</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></code></span>, readonly       </dt>
-        <dd>
-          <p>Indicates whether the asynchronous continuation of an <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> or <code><a href="#dom-sourcebuffer-remove">remove()</a></code> operation is still being processed. This attribute is initially set to false when the object is created.</p>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-buffered" data-idl=""><code>buffered</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code></span>, readonly       </dt>
-        <dd>
-          <p>Indicates what <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> are buffered in the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>. This attribute is initially set to an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object when the object is created.
-          </p>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-updating" data-idl="" data-title="updating"><code>updating</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></code></span>, readonly       </dt><dd>
+          <p>Indicates whether the asynchronous continuation of an <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> or <code><a href="#dom-sourcebuffer-remove">remove()</a></code>
+            operation is still being processed. This attribute is initially set to false when the object is created.</p>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-buffered" data-idl="" data-title="buffered"><code>buffered</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code></span>, readonly       </dt><dd>
+          <p>Indicates what <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> are buffered in the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>. This
+          attribute is initially set to an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object when the object is
+          created.</p>
           <p>When the attribute is read the following steps <em class="rfc2119" title="MUST">MUST</em> occur:</p>
           <ol>
             <li>If this object has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>Let <var>highest end time</var> be the largest <a href="#track-buffer-ranges">track buffer ranges</a> end time across all the <a href="#track-buffer">track buffers</a> managed by this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
             <li>Let <var>intersection ranges</var> equal a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> object containing a single range from 0 to <var>highest end time</var>.</li>
             <li>For each audio and video <a href="#track-buffer">track buffer</a> managed by this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>, run the following steps:
-              <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note36"><span>Note</span></div>
-                <p class="">Text <a href="#track-buffer">track-buffers</a> are included in the calculation of <var>highest end time</var>, above, but excluded from the buffered range calculation here. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p>
-              </div>
+                <div class="note" id="issue-container-generatedID-34"><div role="heading" class="note-title marker" id="h-note-34" aria-level="4"><span>Note</span></div><p class="">Text <a href="#track-buffer">track-buffers</a> are included in the calculation of <var>highest end time</var>, above, but excluded from the buffered range calculation here. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p></div>
               <ol>
                 <li>Let <var>track ranges</var> equal the <a href="#track-buffer-ranges">track buffer ranges</a> for the current <a href="#track-buffer">track buffer</a>.</li>
                 <li>If <code><a href="#dom-readystate">readyState</a></code> is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>, then set the end time on the last range in <var>track ranges</var> to <var>highest end time</var>.</li>
@@ -2320,12 +1929,12 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>Replace the ranges in <var>intersection ranges</var> with the <var>new intersection ranges</var>.</li>
               </ol>
             </li>
-            <li>If <var>intersection ranges</var> does not contain the exact same range information as the current value of this attribute, then update the current value of this attribute to
+            <li>If <var>intersection ranges</var> does not contain the exact same range information as the
+              current value of this attribute, then update the current value of this attribute to
               <var>intersection ranges</var>.</li>
             <li>Return the current value of this attribute.</li>
           </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-timestampoffset" data-idl=""><code>timestampOffset</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-timestampoffset" data-idl="" data-title="timestampOffset"><code>timestampOffset</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span></dt><dd>
           <p>Controls the offset applied to timestamps inside subsequent <a href="#media-segment">media segments</a> that are appended to this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>. The <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> is initially set to 0 which indicates that no offset is being applied.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
@@ -2344,17 +1953,13 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>If the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>, then set the <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> to <var>new timestamp offset</var>.</li>
             <li>Update the attribute to <var>new timestamp offset</var>.</li>
           </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-audiotracks" data-idl=""><code>audioTracks</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code></span>, readonly       </dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-audiotracks" data-idl="" data-title="audioTracks"><code>audioTracks</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code></span>, readonly       </dt><dd>
           The list of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> objects created by this object.
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-videotracks" data-idl=""><code>videoTracks</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code></span>, readonly       </dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-videotracks" data-idl="" data-title="videoTracks"><code>videoTracks</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code></span>, readonly       </dt><dd>
           The list of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> objects created by this object.
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-texttracks" data-idl=""><code>textTracks</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code></span>, readonly       </dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-texttracks" data-idl="" data-title="textTracks"><code>textTracks</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code></span>, readonly       </dt><dd>
           The list of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> objects created by this object.
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-appendwindowstart" data-idl=""><code>appendWindowStart</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-appendwindowstart" data-idl="" data-title="appendWindowStart"><code>appendWindowStart</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></span></dt><dd>
           <p>The <a href="#presentation-timestamp">presentation timestamp</a> for the start of the <a href="#append-window">append window</a>. This attribute is initially set to the <a href="#presentation-start-time">presentation start time</a>.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
@@ -2362,11 +1967,11 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>If this object has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a>, then throw an
               <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
-            <li>If the new value is less than 0 or greater than or equal to <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> then throw a <code>TypeError</code> exception and abort these steps.</li>
+            <li>If the new value is less than 0 or greater than or equal to <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> then throw a <code>TypeError</code> exception
+              and abort these steps.</li>
             <li>Update the attribute to the new value.</li>
           </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-appendwindowend" data-idl=""><code>appendWindowEnd</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-appendwindowend" data-idl="" data-title="appendWindowEnd"><code>appendWindowEnd</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></span></dt><dd>
           <p>The <a href="#presentation-timestamp">presentation timestamp</a> for the end of the <a href="#append-window">append window</a>. This attribute is initially set to positive Infinity.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
@@ -2375,73 +1980,36 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
               <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the new value equals NaN, then throw a <code>TypeError</code> and abort these steps.</li>
-            <li>If the new value is less than or equal to <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> then throw a <code>TypeError</code> exception and abort these steps.
-            </li>
+            <li>If the new value is less than or equal to <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> then throw a <code>TypeError</code> exception and abort these
+              steps.</li>
             <li>Update the attribute to the new value.</li>
           </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onupdatestart" data-idl=""><code>onupdatestart</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onupdatestart" data-idl="" data-title="onupdatestart"><code>onupdatestart</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-updatestart">updatestart</a></code> event.</p>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onupdate" data-idl=""><code>onupdate</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onupdate" data-idl="" data-title="onupdate"><code>onupdate</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-update">update</a></code> event.</p>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onupdateend" data-idl=""><code>onupdateend</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onupdateend" data-idl="" data-title="onupdateend"><code>onupdateend</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-updateend">updateend</a></code> event.</p>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onerror" data-idl=""><code>onerror</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onerror" data-idl="" data-title="onerror"><code>onerror</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-error">error</a></code> event.</p>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onabort" data-idl=""><code>onabort</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
+        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-onabort" data-idl="" data-title="onabort"><code>onabort</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt><dd>
           <p>The event handler for the <code><a href="#dom-evt-abort">abort</a></code> event.</p>
-        </dd>
-      </dl>
-    </section>
-
-    <section id="methods-1" typeof="bibo:Chapter" resource="#methods-1" property="bibo:hasPart">
-      <h3 id="h-methods-1" resource="#h-methods-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Methods</span>
-      </h3>
-      <dl class="methods" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer"><dt><dfn id="dom-sourcebuffer-appendbuffer" data-dfn-for="sourcebuffer" data-dfn-type="dfn" data-idl=""><code>appendBuffer</code></dfn></dt>
-        <dd>
+        </dd></dl></section><section id="methods-0"><h3 id="x3-2-methods"><span class="secno">3.2 </span>Methods</h3><dl class="methods" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer"><dt><dfn id="dom-sourcebuffer-appendbuffer" data-dfn-for="sourcebuffer" data-dfn-type="dfn" data-idl="" data-title="appendBuffer" data-lt="appendBuffer|appendbuffer()"><code>appendBuffer</code></dfn></dt><dd>
           <p>Appends the segment data in an <code><a href="https://www.w3.org/TR/WebIDL-1/#common-BufferSource" class="idlType">BufferSource</a></code>[<cite><a class="bibref" href="#bib-WEBIDL">WEBIDL</a></cite>] to the source buffer.</p>
 
-
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">data</td>
-                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#common-BufferSource">BufferSource</a></code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">data</td><td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#common-BufferSource">BufferSource</a></code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>Run the <a href="#sourcebuffer-prepare-append">prepare append</a> algorithm.</li>
             <li>Add <var>data</var> to the end of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
             <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to true.</li>
             <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updatestart">updatestart</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
             <li>Asynchronously run the <a href="#sourcebuffer-buffer-append">buffer append</a> algorithm.</li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-abort" data-idl=""><code>abort</code></dfn></dt>
-        <dd>
+          </ol></dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-abort" data-idl="" data-title="abort" data-lt="abort|abort()"><code>abort</code></dfn></dt><dd>
           <p>Aborts the current segment and resets the segment parser.</p>
 
-
-          <div><em>No parameters.</em></div>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+        <div>
+          </div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>If this object has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> is not in the <code><a href="#idl-def-ReadyState.open">"open"</a></code> state then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <a href="#sourcebuffer-range-removal">range removal</a> algorithm is running, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
@@ -2456,12 +2024,9 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>Run the <a href="#sourcebuffer-reset-parser-state">reset parser state algorithm</a>.</li>
             <li>Set <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> to the <a href="#presentation-start-time">presentation start time</a>.</li>
             <li>Set <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> to positive Infinity.</li>
-          </ol>
-        </dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-remove" data-idl=""><code>remove</code></dfn></dt>
-        <dd>
-          <p>Removes media for a specific time range.</p>
-
-
+          </ol></dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-changetype" data-idl="" data-title="changeType" data-lt="changeType|changetype()"><code>changeType</code></dfn></dt><dd>
+          <p>Changes the MIME type associated with this object. Subsequent <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> calls will expect the newly appended bytes to conform to the new type.
+          </p>
           <table class="parameters">
             <tbody>
               <tr>
@@ -2472,29 +2037,19 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <th>Description</th>
               </tr>
               <tr>
-                <td class="prmName">start</td>
-                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></td>
-                <td class="prmNullFalse"><span aria-label="False" role="img">✘</span></td>
-                <td class="prmOptFalse"><span aria-label="False" role="img">✘</span></td>
-                <td class="prmDesc">The start of the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</td>
-              </tr>
-              <tr>
-                <td class="prmName">end</td>
-                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></td>
-                <td class="prmNullFalse"><span aria-label="False" role="img">✘</span></td>
-                <td class="prmOptFalse"><span aria-label="False" role="img">✘</span></td>
-                <td class="prmDesc">The end of the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</td>
+                <td class="prmName">type</td>
+                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></td>
+                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
+                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
+                <td class="prmDesc"></td>
               </tr>
             </tbody>
           </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
-            <li>If this object has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
+        <p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
+            <li>If <var>type</var> is an empty string then throw a <code>TypeError</code> exception and abort these steps.</li>
+            <li>If this object has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a>, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
             <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
-            <li>If <code><a href="#dom-mediasource-duration">duration</a></code> equals NaN, then throw a <code>TypeError</code> exception and abort these steps.</li>
-            <li>If <var>start</var> is negative or greater than <code><a href="#dom-mediasource-duration">duration</a></code>, then throw a <code>TypeError</code> exception and abort these steps.</li>
-            <li>If <var>end</var> is less than or equal to <var>start</var> or <var>end</var> equals NaN, then throw a <code>TypeError</code> exception and abort these steps.</li>
+            <li>If <var>type</var> contains a MIME type that is not supported or contains a MIME type that is not supported with the types specified (currently or previously) of <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a>, then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#notsupportederror">NotSupportedError</a></code> exception and abort these steps.</li>
             <li>
               <p>If the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> is in the <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> state then run the following steps:</p>
               <ol>
@@ -2502,716 +2057,790 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceopen">sourceopen</a></code> at the <a href="#parent-media-source">parent media source</a>.</li>
               </ol>
             </li>
-            <li>Run the <a href="#sourcebuffer-range-removal">range removal</a> algorithm with <var>start</var> and <var>end</var> as the start and end of the removal range.</li>
-          </ol>
-        </dd>
-      </dl>
-    </section>
+            <li>Run the <a href="#sourcebuffer-reset-parser-state">reset parser state algorithm</a>.</li>
+            <li>Update the <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object to the value in the
+                 "Generate Timestamps Flag" column of the byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] entry
+                 that is associated with <var>type</var>.</li>
+            <li>
+                <dl class="switch">
+                  <dt>If the <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true:</dt>
+                  <dd>
+                    Set the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object to <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>, including running the associated steps for that attribute being set.
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    Keep the previous value of the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object, without running any associated steps for that attribute being set.
+                  </dd>
+                </dl>
+            </li>
+            <li>Set <var><a href="#pending-init-segment-for-changetype-flag">pending initialization segment for changeType flag</a></var> to true.
+          </li></ol></dd><dt><dfn data-dfn-for="sourcebuffer" data-dfn-type="dfn" id="dom-sourcebuffer-remove" data-idl="" data-title="remove" data-lt="remove|remove()"><code>remove</code></dfn></dt><dd>
+        <p>Removes media for a specific time range.</p>
+        
 
-    <section id="track-buffers" typeof="bibo:Chapter" resource="#track-buffers" property="bibo:hasPart">
-      <h3 id="h-track-buffers" resource="#h-track-buffers"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3 </span>Track Buffers</span>
-      </h3>
-      <p>A <dfn id="track-buffer" data-dfn-type="dfn">track buffer</dfn> stores the <a href="#track-description">track descriptions</a> and <a href="#coded-frame">coded frames</a> for an individual track. The track buffer is updated as <a href="#init-segment">initialization segments</a> and <a href="#media-segment">media segments</a> are appended to the
-        <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</p>
-
-      <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="last-decode-timestamp" data-dfn-type="dfn">last decode timestamp</dfn> variable that stores the decode timestamp of the last <a href="#coded-frame">coded frame</a> appended in the current <a href="#coded-frame-group">coded frame group</a>. The variable is initially unset to indicate that no <a href="#coded-frame">coded frames</a> have been appended yet.</p>
-
-      <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="last-frame-duration" data-dfn-type="dfn">last frame duration</dfn> variable that stores the <a href="#coded-frame-duration">coded frame duration</a> of the last <a href="#coded-frame">coded frame</a> appended in the current <a href="#coded-frame-group">coded frame group</a>. The variable is initially unset to indicate that no <a href="#coded-frame">coded frames</a> have been appended yet.</p>
-
-      <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="highest-end-timestamp" data-dfn-type="dfn">highest end timestamp</dfn> variable that stores the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#coded-frame">coded frames</a> in the current <a href="#coded-frame-group">coded frame group</a> that were appended to this track buffer. The variable is initially unset to indicate that no <a href="#coded-frame">coded frames</a> have been appended yet.</p>
-
-      <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="need-RAP-flag" data-dfn-type="dfn">need random access point flag</dfn> variable that keeps track of whether the track buffer is waiting for a <a href="#random-access-point">random access point</a> <a href="#coded-frame">coded frame</a>. The variable is initially set to true to indicate that <a href="#random-access-point">random access point</a> <a href="#coded-frame">coded frame</a> is needed before anything can be added to the
-        <a href="#track-buffer">track buffer</a>.</p>
-
-      <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="track-buffer-ranges" data-dfn-type="dfn">track buffer ranges</dfn> variable that represents the presentation time ranges occupied by the <a href="#coded-frame">coded frames</a> currently stored in the track buffer.</p>
-
-      <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note37"><span>Note</span></div>
-        <p class="">For track buffer ranges, these presentation time ranges are based on <a href="#presentation-timestamp">presentation timestamps</a>, frame durations, and potentially coded frame group start times for coded frame groups across track buffers in a muxed <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</p>
-      </div>
-
-      <p>For specification purposes, this information is treated as if it were stored in a <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a>. Intersected <a href="#track-buffer-ranges">track buffer ranges</a> are used to report <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code>, and <em class="rfc2119" title="MUST">MUST</em> therefore support uninterrupted playback within each range of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code>.</p>
-
-      <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note38"><span>Note</span></div>
-        <p class="">These coded frame group start times differ slightly from those mentioned in the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> in that they are the earliest <a href="#presentation-timestamp">presentation timestamp</a> across all track buffers following a discontinuity. Discontinuities can occur within the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> or result from the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a>, regardless of <code><a href="#dom-sourcebuffer-mode">mode</a></code>. The threshold for determining disjointness of <a href="#track-buffer-ranges">track buffer ranges</a> is implementation-specific. For example, to reduce unexpected playback stalls, implementations <em class="rfc2119" title="MAY">MAY</em> approximate the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>'s discontinuity detection logic by coalescing adjacent ranges separated by a gap smaller than 2 times the maximum frame duration buffered so far in this <a href="#track-buffer">track buffer</a>. Implementations <em class="rfc2119" title="MAY">MAY</em> also use coded frame group start times as range start times across <a href="#track-buffer">track buffers</a> in a muxed <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to further reduce unexpected playback stalls.</p>
-      </div>
-    </section>
-
-    <section id="sourcebuffer-events" typeof="bibo:Chapter" resource="#sourcebuffer-events" property="bibo:hasPart">
-      <h3 id="h-sourcebuffer-events" resource="#h-sourcebuffer-events"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.4 </span>Event Summary</span>
-      </h3>
-      <table class="old-table">
-        <thead>
-          <tr>
-            <th>Event name</th>
-            <th>Interface</th>
-            <th>Dispatched when...</th>
-          </tr>
-        </thead>
+      <table class="parameters">
         <tbody>
           <tr>
-            <td><dfn id="dom-evt-updatestart"><code>updatestart</code></dfn></td>
-            <td><code>Event</code></td>
-            <td><code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from false to true.</td>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Nullable</th>
+            <th>Optional</th>
+            <th>Description</th>
           </tr>
           <tr>
-            <td><dfn id="dom-evt-update"><code>update</code></dfn></td>
-            <td><code>Event</code></td>
-            <td>The append or remove has successfully completed. <code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from true to false.</td>
+            <td class="prmName">start</td>
+            <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-double">double</a></code></td>
+            <td class="prmNullFalse"><span aria-label="False" role="img">✘</span></td>
+            <td class="prmOptFalse"><span aria-label="False" role="img">✘</span></td>
+            <td class="prmDesc">The start of the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</td>
           </tr>
           <tr>
-            <td><dfn id="dom-evt-updateend"><code>updateend</code></dfn></td>
-            <td><code>Event</code></td>
-            <td>The append or remove has ended.</td>
-          </tr>
-          <tr>
-            <td><dfn id="dom-evt-error"><code>error</code></dfn></td>
-            <td><code>Event</code></td>
-            <td>An error occurred during the append. <code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from true to false.</td>
-          </tr>
-          <tr>
-            <td><dfn id="dom-evt-abort"><code>abort</code></dfn></td>
-            <td><code>Event</code></td>
-            <td>The append or remove was aborted by an <code><a href="#dom-sourcebuffer-abort">abort()</a></code> call. <code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from true to false.</td>
+            <td class="prmName">end</td>
+            <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></code></td>
+            <td class="prmNullFalse"><span aria-label="False" role="img">✘</span></td>
+            <td class="prmOptFalse"><span aria-label="False" role="img">✘</span></td>
+            <td class="prmDesc">The end of the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</td>
           </tr>
         </tbody>
       </table>
-    </section>
+        <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-void" class="idlType">void</a></code></div>
+      <p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
+            <li>If this object has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
+            <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
+            <li>If <code><a href="#dom-mediasource-duration">duration</a></code> equals NaN, then throw a <code>TypeError</code> exception and abort these steps.</li>
+            <li>If <var>start</var> is negative or greater than <code><a href="#dom-mediasource-duration">duration</a></code>, then throw a <code>TypeError</code> exception and abort these steps.</li>
+            <li>If <var>end</var> is less than or equal to <var>start</var> or <var>end</var> equals NaN, then throw a <code>TypeError</code> exception and abort these steps.</li>
+            <li>
+              <p>If the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> is in the <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> state then run
+                the following steps:</p>
+              <ol>
+                <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> to <code><a href="#idl-def-ReadyState.open">"open"</a></code></li>
+                <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceopen">sourceopen</a></code> at the <a href="#parent-media-source">parent media source</a>.</li>
+              </ol>
+            </li>
+            <li>Run the <a href="#sourcebuffer-range-removal">range removal</a> algorithm with <var>start</var> and <var>end</var> as the start and end of the removal range.</li>
+       </ol></dd></dl>
+      </section>
 
-    <section id="sourcebuffer-algorithms" typeof="bibo:Chapter" resource="#sourcebuffer-algorithms" property="bibo:hasPart">
-      <h3 id="h-sourcebuffer-algorithms" resource="#h-sourcebuffer-algorithms"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5 </span>Algorithms</span>
-      </h3>
+      <section id="track-buffers">
+        <h3 id="x3-3-track-buffers"><span class="secno">3.3 </span>Track Buffers</h3>
+        <p>A <dfn id="track-buffer" data-dfn-type="dfn">track buffer</dfn> stores the <a href="#track-description">track descriptions</a> and <a href="#coded-frame">coded frames</a> for an individual
+          track. The track buffer is updated as <a href="#init-segment">initialization segments</a> and <a href="#media-segment">media segments</a> are appended to the
+          <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</p>
 
-      <section id="sourcebuffer-segment-parser-loop" typeof="bibo:Chapter" resource="#sourcebuffer-segment-parser-loop" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-segment-parser-loop" resource="#h-sourcebuffer-segment-parser-loop"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.1 </span>Segment Parser Loop</span>
-        </h4>
-        <p>All SourceBuffer objects have an internal <dfn id="sourcebuffer-append-state" data-dfn-type="dfn">append state</dfn> variable that keeps track of the high-level segment parsing state. It is initially set to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a> and can transition to the following states as data is appended.</p>
+        <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="last-decode-timestamp" data-dfn-type="dfn">last decode timestamp</dfn> variable that stores
+          the decode timestamp of the last <a href="#coded-frame">coded frame</a> appended in the current <a href="#coded-frame-group">coded frame group</a>. The variable is initially
+          unset to indicate that no <a href="#coded-frame">coded frames</a> have been appended yet.</p>
+
+        <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="last-frame-duration" data-dfn-type="dfn">last frame duration</dfn> variable that stores
+          the <a href="#coded-frame-duration">coded frame duration</a> of the last <a href="#coded-frame">coded frame</a> appended in the current <a href="#coded-frame-group">coded frame group</a>. The variable is initially
+          unset to indicate that no <a href="#coded-frame">coded frames</a> have been appended yet.</p>
+
+        <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="highest-end-timestamp" data-dfn-type="dfn">highest end timestamp</dfn> variable that stores
+            the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#coded-frame">coded frames</a> in
+            the current <a href="#coded-frame-group">coded frame group</a> that were appended to this track buffer.
+            The variable is initially unset to indicate that no <a href="#coded-frame">coded frames</a> have been appended yet.</p>
+
+        <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="need-RAP-flag" data-dfn-type="dfn">need random access point flag</dfn> variable that keeps track of whether
+          the track buffer is waiting for a <a href="#random-access-point">random access point</a> <a href="#coded-frame">coded frame</a>. The variable is initially set to true to
+          indicate that <a href="#random-access-point">random access point</a> <a href="#coded-frame">coded frame</a> is needed before anything can be added to the
+          <a href="#track-buffer">track buffer</a>.</p>
+
+        <p>Each <a href="#track-buffer">track buffer</a> has a <dfn id="track-buffer-ranges" data-dfn-type="dfn">track buffer ranges</dfn> variable that represents the presentation time ranges occupied by the <a href="#coded-frame">coded frames</a> currently stored in the track buffer.</p>
+
+          <div class="note" id="issue-container-generatedID-35"><div role="heading" class="note-title marker" id="h-note-35" aria-level="4"><span>Note</span></div><p class="">For track buffer ranges, these presentation time ranges are based on <a href="#presentation-timestamp">presentation timestamps</a>, frame durations, and potentially coded frame group start times for coded frame groups across track buffers in a muxed <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</p></div>
+
+          <p>For specification purposes, this information is treated as if it were stored in a <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a>. Intersected <a href="#track-buffer-ranges">track buffer ranges</a> are used to report <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code>, and <em class="rfc2119" title="MUST">MUST</em> therefore support uninterrupted playback within each range of <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code>.</p>
+
+          <div class="note" id="issue-container-generatedID-36"><div role="heading" class="note-title marker" id="h-note-36" aria-level="4"><span>Note</span></div><p class="">These coded frame group start times differ slightly from those mentioned in the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> in that they are the earliest <a href="#presentation-timestamp">presentation timestamp</a> across all track buffers following a discontinuity. Discontinuities can occur within the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> or result from the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a>, regardless of <code><a href="#dom-sourcebuffer-mode">mode</a></code>.
+          The threshold for determining disjointness of <a href="#track-buffer-ranges">track buffer ranges</a> is implementation-specific. For example, to reduce unexpected playback stalls, implementations <em class="rfc2119" title="MAY">MAY</em> approximate the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>'s discontinuity detection logic by coalescing adjacent ranges separated by a gap smaller than 2 times the maximum frame duration buffered so far in this <a href="#track-buffer">track buffer</a>. Implementations <em class="rfc2119" title="MAY">MAY</em> also use coded frame group start times as range start times across <a href="#track-buffer">track buffers</a> in a muxed <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to further reduce unexpected playback stalls.</p></div>
+      </section>
+
+      <section id="sourcebuffer-events">
+        <h3 id="x3-4-event-summary"><span class="secno">3.4 </span>Event Summary</h3>
         <table class="old-table">
           <thead>
             <tr>
-              <th>Append state name</th>
-              <th>Description</th>
+              <th>Event name</th>
+              <th>Interface</th>
+              <th>Dispatched when...</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td><dfn id="sourcebuffer-waiting-for-segment" data-dfn-type="dfn">WAITING_FOR_SEGMENT</dfn></td>
-              <td>Waiting for the start of an <a href="#init-segment">initialization segment</a> or <a href="#media-segment">media segment</a> to be appended.</td>
+              <td><dfn id="dom-evt-updatestart"><code>updatestart</code></dfn></td>
+              <td><code>Event</code></td>
+              <td><code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from false to true.</td>
             </tr>
             <tr>
-              <td><dfn id="sourcebuffer-parsing-init-segment" data-dfn-type="dfn">PARSING_INIT_SEGMENT</dfn></td>
-              <td>Currently parsing an <a href="#init-segment">initialization segment</a>.</td>
+              <td><dfn id="dom-evt-update"><code>update</code></dfn></td>
+              <td><code>Event</code></td>
+              <td>The append or remove has successfully completed. <code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from true to false.</td>
             </tr>
             <tr>
-              <td><dfn id="sourcebuffer-parsing-media-segment" data-dfn-type="dfn">PARSING_MEDIA_SEGMENT</dfn></td>
-              <td>Currently parsing a <a href="#media-segment">media segment</a>.</td>
+              <td><dfn id="dom-evt-updateend"><code>updateend</code></dfn></td>
+              <td><code>Event</code></td>
+              <td>The append or remove has ended.</td>
+            </tr>
+            <tr>
+              <td><dfn id="dom-evt-error"><code>error</code></dfn></td>
+              <td><code>Event</code></td>
+              <td>An error occurred during the append. <code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from true to false.</td>
+            </tr>
+            <tr>
+              <td><dfn id="dom-evt-abort"><code>abort</code></dfn></td>
+              <td><code>Event</code></td>
+              <td>The append or remove was aborted by an <code><a href="#dom-sourcebuffer-abort">abort()</a></code> call. <code><a href="#dom-sourcebuffer-updating">updating</a></code> transitions from true to false.</td>
             </tr>
           </tbody>
         </table>
+      </section>
 
-        <p>The <dfn id="sourcebuffer-input-buffer" data-dfn-type="dfn">input buffer</dfn> is a byte buffer that is used to hold unparsed bytes across <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> calls. The buffer is empty when the SourceBuffer object is created.</p>
+      <section id="sourcebuffer-algorithms">
+        <h3 id="x3-5-algorithms"><span class="secno">3.5 </span>Algorithms</h3>
 
-        <p>The <dfn id="sourcebuffer-buffer-full-flag" data-dfn-type="dfn">buffer full flag</dfn> keeps track of whether <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> is allowed to accept more bytes. It is set to false when the SourceBuffer object is created and gets updated as data is appended and removed.</p>
+        <section id="sourcebuffer-segment-parser-loop">
+          <h4 id="x3-5-1-segment-parser-loop"><span class="secno">3.5.1 </span>Segment Parser Loop</h4>
+          <p>All SourceBuffer objects have an internal <dfn id="sourcebuffer-append-state" data-dfn-type="dfn">append state</dfn> variable that keeps track of the high-level segment parsing state. It is initially set to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a> and can transition to the following states as data is appended.</p>
+          <table class="old-table">
+            <thead>
+              <tr>
+                <th>Append state name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><dfn id="sourcebuffer-waiting-for-segment" data-dfn-type="dfn">WAITING_FOR_SEGMENT</dfn></td>
+                <td>Waiting for the start of an <a href="#init-segment">initialization segment</a> or <a href="#media-segment">media segment</a> to be appended.</td>
+              </tr>
+              <tr>
+                <td><dfn id="sourcebuffer-parsing-init-segment" data-dfn-type="dfn">PARSING_INIT_SEGMENT</dfn></td>
+                <td>Currently parsing an <a href="#init-segment">initialization segment</a>.</td>
+              </tr>
+              <tr>
+                <td><dfn id="sourcebuffer-parsing-media-segment" data-dfn-type="dfn">PARSING_MEDIA_SEGMENT</dfn></td>
+                <td>Currently parsing a <a href="#media-segment">media segment</a>.</td>
+              </tr>
+            </tbody>
+          </table>
 
-        <p>The <dfn id="sourcebuffer-group-start-timestamp" data-dfn-type="dfn">group start timestamp</dfn> variable keeps track of the starting timestamp for a new
-          <a href="#coded-frame-group">coded frame group</a> in the <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> mode. It is unset when the SourceBuffer object is created and gets updated when the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> and the
-          <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> attribute is set, or the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> runs.
-        </p>
+          <p>The <dfn id="sourcebuffer-input-buffer" data-dfn-type="dfn">input buffer</dfn> is a byte buffer that is used to hold unparsed bytes across <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> calls. The buffer is empty when the SourceBuffer object is created.</p>
 
-        <p>The <dfn id="sourcebuffer-group-end-timestamp" data-dfn-type="dfn">group end timestamp</dfn> variable stores the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#coded-frame">coded frames</a> in the current <a href="#coded-frame-group">coded frame group</a>. It is set to 0 when the SourceBuffer object is created and gets updated by the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
-        </p>
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note39"><span>Note</span></div>
-          <p class="">The <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> stores the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#track-buffer">track buffers</a> in a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>. Therefore, care should be taken in setting the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute when appending multiplexed segments in which the timestamps are not aligned across tracks.
+          <p>The <dfn id="sourcebuffer-buffer-full-flag" data-dfn-type="dfn">buffer full flag</dfn> keeps track of whether <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code>
+            is allowed to accept more bytes. It is set to false when the SourceBuffer object is created and gets updated
+            as data is appended and removed.</p>
+
+          <p>The <dfn id="sourcebuffer-group-start-timestamp" data-dfn-type="dfn">group start timestamp</dfn> variable keeps track of the starting timestamp for a new
+            <a href="#coded-frame-group">coded frame group</a> in the <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> mode.
+            It is unset when the SourceBuffer object is created and gets updated when the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> and the
+            <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> attribute is set, or the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> runs.
           </p>
-        </div>
 
-        <p>The <dfn id="sourcebuffer-generate-timestamps-flag" data-dfn-type="dfn">generate timestamps flag</dfn> is a boolean variable that keeps track of whether timestamps need to be generated for the
-          <a href="#coded-frame">coded frames</a> passed to the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>. This flag is set by <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> when the SourceBuffer object is created.
-        </p>
-        <p>When the segment parser loop algorithm is invoked, run the following steps:</p>
+          <p>The <dfn id="sourcebuffer-group-end-timestamp" data-dfn-type="dfn">group end timestamp</dfn> variable stores the
+            highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#coded-frame">coded frames</a> in
+            the current <a href="#coded-frame-group">coded frame group</a>. It is set to 0 when the SourceBuffer object is created and gets updated
+            by the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
+          </p>
+          <div class="note" id="issue-container-generatedID-37"><div role="heading" class="note-title marker" id="h-note-37" aria-level="5"><span>Note</span></div><p class="">The <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> stores the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#track-buffer">track buffers</a> in a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>. Therefore, care should be taken in setting the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute when appending multiplexed segments in which the timestamps are not aligned across tracks.
+          </p></div>
 
-        <ol>
-          <li><i>Loop Top:</i> If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> is empty, then jump to the <i>need more data</i> step below.</li>
-          <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains bytes that violate the <a href="#sourcebuffer-byte-stream-format-spec">SourceBuffer byte stream format specification</a>, then run the
-            <a href="#sourcebuffer-append-error">append error algorithm</a> and abort this algorithm.</li>
-          <li>Remove any bytes that the <a href="#byte-stream-format-specs">byte stream format specifications</a> say <em class="rfc2119" title="MUST">MUST</em> be ignored from the start of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
-          <li>
-            <p>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>, then run the following steps:</p>
+          <p>The <dfn id="sourcebuffer-generate-timestamps-flag" data-dfn-type="dfn">generate timestamps flag</dfn> is a
+            boolean variable that keeps track of whether timestamps need to be generated for the
+            <a href="#coded-frame">coded frames</a> passed to the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
+            This flag is set by <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> when the SourceBuffer object is created.
+          </p>
+          <p>When the segment parser loop algorithm is invoked, run the following steps:</p>
+
+          <ol>
+            <li><i>Loop Top:</i> If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> is empty, then jump to the <i>need more data</i> step below.</li>
+            <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains bytes that violate the <a href="#sourcebuffer-byte-stream-format-spec">SourceBuffer byte stream format specification</a>, then run the
+              <a href="#sourcebuffer-append-error">append error algorithm</a> and abort this algorithm.</li>
+            <li>Remove any bytes that the <a href="#byte-stream-format-specs">byte stream format specifications</a> say <em class="rfc2119" title="MUST">MUST</em> be ignored from the start of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
+            <li>
+              <p>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>, then run the following steps:</p>
+              <ol>
+                <li>If the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> indicates the start of an <a href="#init-segment">initialization segment</a>, set the <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-parsing-init-segment">PARSING_INIT_SEGMENT</a>.</li>
+                <li>If the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> indicates the start of a <a href="#media-segment">media segment</a>, set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-parsing-media-segment">PARSING_MEDIA_SEGMENT</a>.</li>
+                <li>Jump to the <i>loop top</i> step above.</li>
+              </ol>
+            </li>
+            <li>
+              <p>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-parsing-init-segment">PARSING_INIT_SEGMENT</a>, then run the following steps:</p>
+              <ol>
+                <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> does not contain a complete <a href="#init-segment">initialization segment</a> yet, then jump to the <i>need more data</i> step below.</li>
+                <li>Run the <a href="#sourcebuffer-init-segment-received">initialization segment received algorithm</a>.</li>
+                <li>Remove the <a href="#init-segment">initialization segment</a> bytes from the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
+                <li>Set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>.</li>
+                <li>Jump to the <i>loop top</i> step above.</li>
+              </ol>
+            </li>
+            <li>
+              <p>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-parsing-media-segment">PARSING_MEDIA_SEGMENT</a>, then run the following steps:</p>
+              <ol>
+                <li>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is false or the <var><a href="#pending-init-segment-for-changetype-flag">pending initialization segment for changeType flag</a></var> is true, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort this algorithm.</li>
+                <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains one or more complete <a href="#coded-frame">coded frames</a>, then run the
+                  <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
+                  <div class="note" id="issue-container-generatedID-38"><div role="heading" class="note-title marker" id="h-note-38" aria-level="5"><span>Note</span></div><p class="">
+                    The frequency at which the coded frame processing algorithm is run is implementation-specific. The coded frame processing algorithm <em class="rfc2119" title="MAY">MAY</em>
+                    be called when the input buffer contains the complete media segment or it <em class="rfc2119" title="MAY">MAY</em> be called multiple times as complete coded frames are
+                    added to the input buffer.
+                  </p></div>
+                </li>
+                <li>If this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> is full and cannot accept more media data, then set the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> to true.</li>
+                <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> does not contain a complete <a href="#media-segment">media segment</a>, then jump to the <i>need more data</i> step below.</li>
+                <li>Remove the <a href="#media-segment">media segment</a> bytes from the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
+                <li>Set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>.</li>
+                <li>Jump to the <i>loop top</i> step above.</li>
+              </ol>
+            </li>
+            <li><i>Need more data:</i> Return control to the calling algorithm.</li>
+          </ol>
+        </section>
+
+        <section id="sourcebuffer-reset-parser-state">
+          <h4 id="x3-5-2-reset-parser-state"><span class="secno">3.5.2 </span>Reset Parser State</h4>
+          <p>When the parser state needs to be reset, run the following steps:</p>
+          <ol>
+            <li>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-parsing-media-segment">PARSING_MEDIA_SEGMENT</a> and the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains some
+              complete <a href="#coded-frame">coded frames</a>, then run the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> until all of these complete
+              <a href="#coded-frame">coded frames</a> have been processed.</li>
+            <li>Unset the <var><a href="#last-decode-timestamp">last decode timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
+            <li>Unset the <var><a href="#last-frame-duration">last frame duration</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
+            <li>Unset the <var><a href="#highest-end-timestamp">highest end timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
+            <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
+            <li>If the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>, then set the <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> to the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var></li>
+            <li>Remove all bytes from the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
+            <li>Set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>.</li>
+          </ol>
+        </section>
+
+        <section id="sourcebuffer-append-error">
+          <h4 id="x3-5-3-append-error-algorithm"><span class="secno">3.5.3 </span>Append Error Algorithm</h4>
+          <p>This algorithm is called when an error occurs during an append.
+          </p><ol>
+            <li>Run the <a href="#sourcebuffer-reset-parser-state">reset parser state algorithm</a>.</li>
+            <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to false.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-error">error</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updateend">updateend</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+            <li>Run the <a href="#end-of-stream-algorithm">end of stream algorithm</a>
+              with the <var>error</var> parameter set to <code><a href="#idl-def-EndOfStreamError.decode">"decode"</a></code>.</li>
+          </ol>
+        </section>
+
+        <section id="sourcebuffer-prepare-append">
+            <h4 id="x3-5-4-prepare-append-algorithm"><span class="secno">3.5.4 </span>Prepare Append Algorithm</h4>
+            <p>When an append operation begins, the follow steps are run to validate and prepare the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</p>
             <ol>
-              <li>If the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> indicates the start of an <a href="#init-segment">initialization segment</a>, set the <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-parsing-init-segment">PARSING_INIT_SEGMENT</a>.</li>
-              <li>If the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> indicates the start of a <a href="#media-segment">media segment</a>, set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-parsing-media-segment">PARSING_MEDIA_SEGMENT</a>.</li>
-              <li>Jump to the <i>loop top</i> step above.</li>
+            <li>If the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
+            <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
+            <li>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-error">HTMLMediaElement.error</a></code> attribute is not null, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
+            <li>
+              <p>If the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> is in the <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> state then run the following steps:</p>
+              <ol>
+                <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> to <code><a href="#idl-def-ReadyState.open">"open"</a></code>
+                </li>
+                <li>
+                  <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceopen">sourceopen</a></code> at the <a href="#parent-media-source">parent media source</a>.</li>
+              </ol>
+            </li>
+            <li>Run the <a href="#sourcebuffer-coded-frame-eviction">coded frame eviction algorithm</a>.</li>
+            <li>
+              <p>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals true, then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#quotaexceedederror">QuotaExceededError</a></code> exception and abort these step.</p>
+              <div class="note" id="issue-container-generatedID-39"><div role="heading" class="note-title marker" id="h-note-39" aria-level="5"><span>Note</span></div><p class="">This is the signal that the implementation was unable to evict enough data to accommodate the append or the append is too big. The web
+                application <em class="rfc2119" title="SHOULD">SHOULD</em> use <code><a href="#dom-sourcebuffer-remove">remove()</a></code> to explicitly free up space and/or reduce the size of the append.</p></div>
+            </li>
             </ol>
-          </li>
-          <li>
-            <p>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-parsing-init-segment">PARSING_INIT_SEGMENT</a>, then run the following steps:</p>
-            <ol>
-              <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> does not contain a complete <a href="#init-segment">initialization segment</a> yet, then jump to the <i>need more data</i> step below.</li>
-              <li>Run the <a href="#sourcebuffer-init-segment-received">initialization segment received algorithm</a>.</li>
-              <li>Remove the <a href="#init-segment">initialization segment</a> bytes from the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
-              <li>Set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>.</li>
-              <li>Jump to the <i>loop top</i> step above.</li>
-            </ol>
-          </li>
-          <li>
-            <p>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-parsing-media-segment">PARSING_MEDIA_SEGMENT</a>, then run the following steps:</p>
-            <ol>
-              <li>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is false, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort this algorithm.</li>
-              <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains one or more complete <a href="#coded-frame">coded frames</a>, then run the
-                <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note40"><span>Note</span></div>
-                  <p class="">
-                    The frequency at which the coded frame processing algorithm is run is implementation-specific. The coded frame processing algorithm <em class="rfc2119" title="MAY">MAY</em> be called when the input buffer contains the complete media segment or it <em class="rfc2119" title="MAY">MAY</em> be called multiple times as complete coded frames are added to the input buffer.
-                  </p>
-                </div>
-              </li>
-              <li>If this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> is full and cannot accept more media data, then set the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> to true.</li>
-              <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> does not contain a complete <a href="#media-segment">media segment</a>, then jump to the <i>need more data</i> step below.</li>
-              <li>Remove the <a href="#media-segment">media segment</a> bytes from the beginning of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
-              <li>Set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>.</li>
-              <li>Jump to the <i>loop top</i> step above.</li>
-            </ol>
-          </li>
-          <li><i>Need more data:</i> Return control to the calling algorithm.</li>
-        </ol>
-      </section>
+        </section>
 
-      <section id="sourcebuffer-reset-parser-state" typeof="bibo:Chapter" resource="#sourcebuffer-reset-parser-state" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-reset-parser-state" resource="#h-sourcebuffer-reset-parser-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.2 </span>Reset Parser State</span>
-        </h4>
-        <p>When the parser state needs to be reset, run the following steps:</p>
-        <ol>
-          <li>If the <var><a href="#sourcebuffer-append-state">append state</a></var> equals <a href="#sourcebuffer-parsing-media-segment">PARSING_MEDIA_SEGMENT</a> and the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains some complete <a href="#coded-frame">coded frames</a>, then run the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> until all of these complete
-            <a href="#coded-frame">coded frames</a> have been processed.</li>
-          <li>Unset the <var><a href="#last-decode-timestamp">last decode timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
-          <li>Unset the <var><a href="#last-frame-duration">last frame duration</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
-          <li>Unset the <var><a href="#highest-end-timestamp">highest end timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
-          <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
-          <li>If the <code><a href="#dom-sourcebuffer-mode">mode</a></code> attribute equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>, then set the <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> to the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var></li>
-          <li>Remove all bytes from the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
-          <li>Set <var><a href="#sourcebuffer-append-state">append state</a></var> to <a href="#sourcebuffer-waiting-for-segment">WAITING_FOR_SEGMENT</a>.</li>
-        </ol>
-      </section>
+        <section id="sourcebuffer-buffer-append">
+          <h4 id="x3-5-5-buffer-append-algorithm"><span class="secno">3.5.5 </span>Buffer Append Algorithm</h4>
+          <p>When <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> is called, the following steps are run to process the appended data.</p>
+          <ol>
+            <li>Run the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</li>
+            <li>If the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm in the previous step was aborted, then abort this algorithm.</li>
+            <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to false.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-update">update</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updateend">updateend</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+          </ol>
+        </section>
 
-      <section id="sourcebuffer-append-error" typeof="bibo:Chapter" resource="#sourcebuffer-append-error" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-append-error" resource="#h-sourcebuffer-append-error"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.3 </span>Append Error Algorithm</span>
-        </h4>
-        <p>This algorithm is called when an error occurs during an append.
-        </p>
-        <ol>
-          <li>Run the <a href="#sourcebuffer-reset-parser-state">reset parser state algorithm</a>.</li>
-          <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to false.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-error">error</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updateend">updateend</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-          <li>Run the <a href="#end-of-stream-algorithm">end of stream algorithm</a> with the <var>error</var> parameter set to <code><a href="#idl-def-EndOfStreamError.decode">"decode"</a></code>.</li>
-        </ol>
-      </section>
-
-      <section id="sourcebuffer-prepare-append" typeof="bibo:Chapter" resource="#sourcebuffer-prepare-append" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-prepare-append" resource="#h-sourcebuffer-prepare-append"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.4 </span>Prepare Append Algorithm</span>
-        </h4>
-        <p>When an append operation begins, the follow steps are run to validate and prepare the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</p>
-        <ol>
-          <li>If the <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of the <a href="#parent-media-source">parent media source</a> then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
-          <li>If the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute equals true, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
-          <li>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-error">HTMLMediaElement.error</a></code> attribute is not null, then throw an <code><a href="https://www.w3.org/TR/WebIDL-1/#invalidstateerror">InvalidStateError</a></code> exception and abort these steps.</li>
-          <li>
-            <p>If the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> is in the <code><a href="#idl-def-ReadyState.ended">"ended"</a></code> state then run the following steps:</p>
-            <ol>
-              <li>Set the <code><a href="#dom-readystate">readyState</a></code> attribute of the <a href="#parent-media-source">parent media source</a> to <code><a href="#idl-def-ReadyState.open">"open"</a></code>
-              </li>
-              <li>
-                <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-sourceopen">sourceopen</a></code> at the <a href="#parent-media-source">parent media source</a>.</li>
-            </ol>
-          </li>
-          <li>Run the <a href="#sourcebuffer-coded-frame-eviction">coded frame eviction algorithm</a>.</li>
-          <li>
-            <p>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals true, then throw a <code><a href="https://www.w3.org/TR/WebIDL-1/#quotaexceedederror">QuotaExceededError</a></code> exception and abort these step.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note41"><span>Note</span></div>
-              <p class="">This is the signal that the implementation was unable to evict enough data to accommodate the append or the append is too big. The web application <em class="rfc2119" title="SHOULD">SHOULD</em> use <code><a href="#dom-sourcebuffer-remove">remove()</a></code> to explicitly free up space and/or reduce the size of the append.</p>
-            </div>
-          </li>
-        </ol>
-      </section>
-
-      <section id="sourcebuffer-buffer-append" typeof="bibo:Chapter" resource="#sourcebuffer-buffer-append" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-buffer-append" resource="#h-sourcebuffer-buffer-append"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.5 </span>Buffer Append Algorithm</span>
-        </h4>
-        <p>When <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> is called, the following steps are run to process the appended data.</p>
-        <ol>
-          <li>Run the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</li>
-          <li>If the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm in the previous step was aborted, then abort this algorithm.</li>
-          <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to false.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-update">update</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updateend">updateend</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-        </ol>
-      </section>
-
-      <section id="sourcebuffer-range-removal" typeof="bibo:Chapter" resource="#sourcebuffer-range-removal" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-range-removal" resource="#h-sourcebuffer-range-removal"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.6 </span>Range Removal</span>
-        </h4>
-        <p>Follow these steps when a caller needs to initiate a JavaScript visible range removal operation that blocks other SourceBuffer updates:</p>
-        <ol>
-          <li>Let <var>start</var> equal the starting <a href="#presentation-timestamp">presentation timestamp</a> for the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</li>
-          <li>Let <var>end</var> equal the end <a href="#presentation-timestamp">presentation timestamp</a> for the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</li>
-          <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to true.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updatestart">updatestart</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-          <li>Return control to the caller and run the rest of the steps asynchronously.</li>
-          <li>Run the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a> with <var>start</var> and <var>end</var> as the start and end of the removal range.</li>
-          <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to false.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-update">update</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-          <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updateend">updateend</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
-        </ol>
-      </section>
-
-      <section id="sourcebuffer-init-segment-received" typeof="bibo:Chapter" resource="#sourcebuffer-init-segment-received" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-init-segment-received" resource="#h-sourcebuffer-init-segment-received"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.7 </span>Initialization Segment Received</span>
-        </h4>
-        <p>The following steps are run when the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> successfully parses a complete <a href="#init-segment">initialization segment</a>:</p>
-        <p>Each SourceBuffer object has an internal <dfn id="first-init-segment-received-flag" data-dfn-type="dfn">first initialization segment received flag</dfn> that tracks whether the first <a href="#init-segment">initialization segment</a> has been appended and received by this algorithm. This flag is set to false when the SourceBuffer is created and updated by the algorithm below.</p>
-        <ol>
-          <li>Update the <code><a href="#dom-mediasource-duration">duration</a></code> attribute if it currently equals NaN:
-            <dl class="switch">
-              <dt>If the initialization segment contains a duration:</dt>
-              <dd>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the duration in the initialization segment.</dd>
-              <dt>Otherwise:</dt>
-              <dd>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to positive Infinity.</dd>
-            </dl>
-          </li>
-          <li>If the <a href="#init-segment">initialization segment</a> has no audio, video, or text tracks, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort these steps.</li>
-          <li>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is true, then run the following steps:
-            <ol>
-              <li>Verify the following properties. If any of the checks fail then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort these steps.
-                <ul>
-                  <li>The number of audio, video, and text tracks match what was in the first <a href="#init-segment">initialization segment</a>.</li>
-                  <li>The codecs for each track, match what was specified in the first <a href="#init-segment">initialization segment</a>.</li>
-                  <li>If more than one track for a single type are present (e.g., 2 audio tracks), then the <a href="#track-id">Track IDs</a> match the ones in the first <a href="#init-segment">initialization segment</a>.</li>
-                </ul>
-              </li>
-              <li>Add the appropriate <a href="#track-description">track descriptions</a> from this <a href="#init-segment">initialization segment</a> to each of the
-                <a href="#track-buffer">track buffers</a>.</li>
-              <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all track buffers to true.</li>
-            </ol>
-          </li>
-          <li>Let <var>active track flag</var> equal false.</li>
-          <li>
-            <p>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is false, then run the following steps:</p>
-            <ol>
-              <li>If the <a href="#init-segment">initialization segment</a> contains tracks with codecs the user agent does not support, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort these steps.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note42"><span>Note</span></div>
-                  <p class="">User agents <em class="rfc2119" title="MAY">MAY</em> consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not specified in the <var>type</var> parameter passed to <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code>. <br> For example, MediaSource.isTypeSupported('video/webm;codecs="vp8,vorbis"') may return true, but if
+        <section id="sourcebuffer-range-removal">
+          <h4 id="x3-5-6-range-removal"><span class="secno">3.5.6 </span>Range Removal</h4>
+          <p>Follow these steps when a caller needs to initiate a JavaScript visible range removal
+            operation that blocks other SourceBuffer updates:</p>
+          <ol>
+            <li>Let <var>start</var> equal the starting <a href="#presentation-timestamp">presentation timestamp</a> for the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</li>
+            <li>Let <var>end</var> equal the end <a href="#presentation-timestamp">presentation timestamp</a> for the removal range, in seconds measured from <a href="#presentation-start-time">presentation start time</a>.</li>
+            <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to true.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updatestart">updatestart</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+            <li>Return control to the caller and run the rest of the steps asynchronously.</li>
+            <li>Run the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a> with <var>start</var> and <var>end</var> as the start and end of the removal range.</li>
+            <li>Set the <code><a href="#dom-sourcebuffer-updating">updating</a></code> attribute to false.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-update">update</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+            <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-updateend">updateend</a></code> at this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.</li>
+          </ol>
+        </section>
+        <section id="sourcebuffer-init-segment-received">
+          <h4 id="x3-5-7-initialization-segment-received"><span class="secno">3.5.7 </span>Initialization Segment Received</h4>
+          <p>The following steps are run when the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> successfully parses a complete <a href="#init-segment">initialization segment</a>:</p>
+          <p>Each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object has an internal <dfn id="first-init-segment-received-flag" data-dfn-type="dfn">
+            first initialization segment received flag</dfn> that tracks whether the first <a href="#init-segment">initialization segment</a>
+            has been appended and received by this algorithm.
+            This flag is set to false when the SourceBuffer is created and is updated by the algorithm below.</p>
+          <p>Each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object has an internal <dfn id="pending-init-segment-for-changetype-flag" data-dfn-type="dfn">
+            pending initialization segment for changeType flag</dfn> that tracks whether an <a href="#init-segment">initialization segment</a>
+            is needed since the most recent <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code>.
+            This flag is set to false when the SourceBuffer is created, set to true by <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> and reset to false
+            by the algorithm below.</p>
+          <ol>
+            <li>Update the <code><a href="#dom-mediasource-duration">duration</a></code> attribute if it currently equals NaN:
+              <dl class="switch">
+                <dt>If the initialization segment contains a duration:</dt>
+                <dd>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the duration in the initialization segment.</dd>
+                <dt>Otherwise:</dt>
+                <dd>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to positive Infinity.</dd>
+              </dl>
+            </li>
+            <li>If the <a href="#init-segment">initialization segment</a> has no audio, video, or text tracks, then run the <a href="#sourcebuffer-append-error">append error algorithm</a>  and abort these steps.</li>
+            <li>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is true, then run the following steps:
+              <ol>
+                <li>Verify the following properties. If any of the checks fail then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort these steps.
+                  <ul>
+                    <li>The number of audio, video, and text tracks match what was in the first <a href="#init-segment">initialization segment</a>.</li>
+                    <li>If more than one track for a single type are present (e.g., 2 audio tracks), then the <a href="#track-id">Track IDs</a> match the ones in the
+                      first <a href="#init-segment">initialization segment</a>.</li>
+                    <li>The codecs for each track are supported by the user agent.
+                      <div class="note" id="issue-container-generatedID-40"><div role="heading" class="note-title marker" id="h-note-40" aria-level="5"><span>Note</span></div><p class="">User agents <em class="rfc2119" title="MAY">MAY</em> consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not
+                        specified in <var>type</var> parameter passed to
+                        (a) the most recently successful <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object, or
+                        (b) if no successful <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> has yet occurred on this object, the <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> that created this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        For example, if the most recently successful <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> was called with 'video/webm'
+                        or 'video/webm; codecs="vp8"', and a video track containing vp9 appears in the initialization segment,
+                        then the user agent <em class="rfc2119" title="MAY">MAY</em> use this step to trigger a decode error even if the other two properties'
+                        checks, above, pass. Implementations are encouraged to trigger error in such cases only when the codec
+                        is indeed not supported or the other two properties' checks fail.
+                      </p></div>
+                    </li>
+                  </ul>
+                </li>
+                <li>Add the appropriate <a href="#track-description">track descriptions</a> from this <a href="#init-segment">initialization segment</a> to each of the
+                  <a href="#track-buffer">track buffers</a>.</li>
+                <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all track buffers to true.</li>
+              </ol>
+            </li>
+            <li>Let <var>active track flag</var> equal false.</li>
+            <li>
+              <p>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is false, then run the following steps:</p>
+              <ol>
+                <li>If the <a href="#init-segment">initialization segment</a> contains tracks with codecs the user agent does not support, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> and abort these steps.
+                  <div class="note" id="issue-container-generatedID-41"><div role="heading" class="note-title marker" id="h-note-41" aria-level="5"><span>Note</span></div><p class="">User agents <em class="rfc2119" title="MAY">MAY</em> consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not
+                    specified in <var>type</var> parameter passed to
+                    (a) the most recently successful <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object, or
+                    (b) if no successful <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> has yet occurred on this object, the <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> that created this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                    For example, MediaSource.isTypeSupported('video/webm;codecs="vp8,vorbis"') may return true, but if
                     <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> was called with 'video/webm;codecs="vp8"' and a Vorbis track appears in the
                     <a href="#init-segment">initialization segment</a>, then the user agent <em class="rfc2119" title="MAY">MAY</em> use this step to trigger a decode error.
-                  </p>
-                </div>
-              </li>
-              <li>
-                <p>For each audio track in the <a href="#init-segment">initialization segment</a>, run following steps:</p>
-                <ol>
-                  <li>Let <var>audio byte stream track ID</var> be the
-                    <a href="#track-id">Track ID</a> for the current track being processed.</li>
-                  <li>Let <var>audio language</var> be a BCP 47 language tag for the language specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no language info is present.</li>
-                  <li>If <var>audio language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>audio language</var>.</li>
-                  <li>Let <var>audio label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no label info is present.</li>
-                  <li>Let <var>audio kinds</var> be a sequence of kind strings specified in the
-                    <a href="#init-segment">initialization segment</a> for this track or a sequence with a single empty string element in it if no kind information is provided.</li>
-                  <li>For each value in <var>audio kinds</var>, run the following steps:
-                    <ol>
-                      <li>Let <var>current audio kind</var> equal the value from <var>audio kinds</var> for this iteration of the loop.</li>
-                      <li>Let <var>new audio track</var> be a new <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object.</li>
-                      <li>Generate a unique ID and assign it to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-id">id</a></code> property on <var>new audio track</var>.</li>
-                      <li>Assign <var>audio language</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-language">language</a></code> property on <var>new audio track</var>.</li>
-                      <li>Assign <var>audio label</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-label">label</a></code> property on <var>new audio track</var>.</li>
-                      <li>Assign <var>current audio kind</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-kind">kind</a></code> property on <var>new audio track</var>.</li>
-                      <li>
-                        <p>
-                          If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code>.<code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotracklist-length">length</a></code> equals 0, then run the following steps:
-                        </p>
-                        <ol>
-                          <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code> property on <var>new audio track</var> to true.</li>
-                          <li>Set <var>active track flag</var> to true.</li>
-                        </ol>
-                      </li>
-                      <li>Add <var>new audio track</var> to the <code><a href="#dom-sourcebuffer-audiotracks">audioTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note43"><span>Note</span></div>
-                          <p class="">
-                            This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to <var>new audio track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> object referenced by the <code><a href="#dom-sourcebuffer-audiotracks">audioTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                    Implementations are encouraged to trigger error in such cases only when the codec is indeed not supported.
+                  </p></div>
+                </li>
+                <li>
+                  <p>For each audio track in the <a href="#init-segment">initialization segment</a>, run following steps:</p>
+                  <ol>
+                    <li>Let <var>audio byte stream track ID</var> be the
+                      <a href="#track-id">Track ID</a> for the current track being processed.</li>
+                    <li>Let <var>audio language</var> be a BCP 47 language tag for the language
+                      specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no
+                      language info is present.</li>
+                    <li>If <var>audio language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>audio language</var>.</li>
+                    <li>Let <var>audio label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no
+                      label info is present.</li>
+                    <li>Let <var>audio kinds</var> be a sequence of kind strings specified in the
+                      <a href="#init-segment">initialization segment</a> for this track
+                      or a sequence with a single empty string element in it
+                      if no kind information is provided.</li>
+                    <li>For each value in <var>audio kinds</var>, run the following steps:
+                      <ol>
+                        <li>Let <var>current audio kind</var> equal the value from <var>audio kinds</var>
+                          for this iteration of the loop.</li>
+                        <li>Let <var>new audio track</var> be a new <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> object.</li>
+                        <li>Generate a unique ID and assign it to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-id">id</a></code> property on <var>new audio track</var>.</li>
+                        <li>Assign <var>audio language</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-language">language</a></code>
+                          property on <var>new audio track</var>.</li>
+                        <li>Assign <var>audio label</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-label">label</a></code>
+                          property on <var>new audio track</var>.</li>
+                        <li>Assign <var>current audio kind</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-kind">kind</a></code>
+                          property on <var>new audio track</var>.</li>
+                        <li>
+                          <p>
+                            If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code>.<code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotracklist-length">length</a></code> equals 0, then run
+                            the following steps:
                           </p>
-                        </div>
-                      </li>
-                      <li>Add <var>new audio track</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code> attribute on the HTMLMediaElement.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note44"><span>Note</span></div>
-                          <p class="">
-                            This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to <var>new audio track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> object referenced by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code> attribute on the HTMLMediaElement.
+                          <ol>
+                            <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-audiotrack-enabled">enabled</a></code> property on <var>new audio track</var> to true.</li>
+                            <li>Set <var>active track flag</var> to true.</li>
+                          </ol>
+                        </li>
+                        <li>Add <var>new audio track</var> to the <code><a href="#dom-sourcebuffer-audiotracks">audioTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        <div class="note" id="issue-container-generatedID-42"><div role="heading" class="note-title marker" id="h-note-42" aria-level="5"><span>Note</span></div><p class="">
+                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  <var>new audio track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> object referenced by the <code><a href="#dom-sourcebuffer-audiotracks">audioTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        </p></div>
+                        </li>
+                        <li>Add <var>new audio track</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code> attribute on the HTMLMediaElement.
+                        <div class="note" id="issue-container-generatedID-43"><div role="heading" class="note-title marker" id="h-note-43" aria-level="5"><span>Note</span></div><p class="">
+                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  <var>new audio track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotracklist-audiotracklist">AudioTrackList</a></code> object referenced by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-audiotracks">audioTracks</a></code> attribute on the HTMLMediaElement.
+                        </p></div>
+                        </li>
+                      </ol>
+                    </li>
+                    <li>Create a new <a href="#track-buffer">track buffer</a> to store <a href="#coded-frame">coded frames</a> for this track.</li>
+                    <li>Add the <a href="#track-description">track description</a> for this track to the <a href="#track-buffer">track buffer</a>.</li>
+                  </ol>
+                </li>
+                <li>
+                  <p>For each video track in the <a href="#init-segment">initialization segment</a>, run following steps:</p>
+                  <ol>
+                    <li>Let <var>video byte stream track ID</var> be the
+                      <a href="#track-id">Track ID</a> for the current track being processed.</li>
+                    <li>Let <var>video language</var> be a BCP 47 language tag for the language
+                      specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no
+                      language info is present.</li>
+                    <li>If <var>video language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>video language</var>.</li>
+                    <li>Let <var>video label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no
+                      label info is present.</li>
+                    <li>Let <var>video kinds</var> be a sequence of kind strings specified in the
+                      <a href="#init-segment">initialization segment</a> for this track
+                      or a sequence with a single empty string element in it
+                      if no kind information is provided.</li>
+                    <li>For each value in <var>video kinds</var>, run the following steps:
+                      <ol>
+                        <li>Let <var>current video kind</var> equal the value from <var>video kinds</var>
+                          for this iteration of the loop.</li>
+                        <li>Let <var>new video track</var> be a new <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object.</li>
+                        <li>Generate a unique ID and assign it to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-id">id</a></code> property on <var>new video track</var>.</li>
+                        <li>Assign <var>video language</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-language">language</a></code>
+                          property on <var>new video track</var>.</li>
+                        <li>Assign <var>video label</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-label">label</a></code>
+                          property on <var>new video track</var>.</li>
+                        <li>Assign <var>current video kind</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-kind">kind</a></code>
+                          property on <var>new video track</var>.</li>
+                        <li>
+                          <p>
+                            If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code>.<code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotracklist-length">length</a></code> equals 0, then run
+                            the following steps:
                           </p>
-                        </div>
-                      </li>
-                    </ol>
-                  </li>
-                  <li>Create a new <a href="#track-buffer">track buffer</a> to store <a href="#coded-frame">coded frames</a> for this track.</li>
-                  <li>Add the <a href="#track-description">track description</a> for this track to the <a href="#track-buffer">track buffer</a>.</li>
-                </ol>
-              </li>
-              <li>
-                <p>For each video track in the <a href="#init-segment">initialization segment</a>, run following steps:</p>
-                <ol>
-                  <li>Let <var>video byte stream track ID</var> be the
-                    <a href="#track-id">Track ID</a> for the current track being processed.</li>
-                  <li>Let <var>video language</var> be a BCP 47 language tag for the language specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no language info is present.</li>
-                  <li>If <var>video language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>video language</var>.</li>
-                  <li>Let <var>video label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no label info is present.</li>
-                  <li>Let <var>video kinds</var> be a sequence of kind strings specified in the
-                    <a href="#init-segment">initialization segment</a> for this track or a sequence with a single empty string element in it if no kind information is provided.</li>
-                  <li>For each value in <var>video kinds</var>, run the following steps:
-                    <ol>
-                      <li>Let <var>current video kind</var> equal the value from <var>video kinds</var> for this iteration of the loop.</li>
-                      <li>Let <var>new video track</var> be a new <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> object.</li>
-                      <li>Generate a unique ID and assign it to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-id">id</a></code> property on <var>new video track</var>.</li>
-                      <li>Assign <var>video language</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-language">language</a></code> property on <var>new video track</var>.</li>
-                      <li>Assign <var>video label</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-label">label</a></code> property on <var>new video track</var>.</li>
-                      <li>Assign <var>current video kind</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-kind">kind</a></code> property on <var>new video track</var>.</li>
-                      <li>
-                        <p>
-                          If <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code>.<code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotracklist-length">length</a></code> equals 0, then run the following steps:
-                        </p>
-                        <ol>
-                          <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> property on <var>new video track</var> to true.</li>
-                          <li>Set <var>active track flag</var> to true.</li>
-                        </ol>
-                      </li>
-                      <li>Add <var>new video track</var> to the <code><a href="#dom-sourcebuffer-videotracks">videoTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note45"><span>Note</span></div>
-                          <p class="">
-                            This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to <var>new video track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> object referenced by the <code><a href="#dom-sourcebuffer-videotracks">videoTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
-                          </p>
-                        </div>
-                      </li>
-                      <li>Add <var>new video track</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code> attribute on the HTMLMediaElement.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note46"><span>Note</span></div>
-                          <p class="">
-                            This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to <var>new video track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> object referenced by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code> attribute on the HTMLMediaElement.
-                          </p>
-                        </div>
-                      </li>
-                    </ol>
-                  </li>
-                  <li>Create a new <a href="#track-buffer">track buffer</a> to store <a href="#coded-frame">coded frames</a> for this track.</li>
-                  <li>Add the <a href="#track-description">track description</a> for this track to the <a href="#track-buffer">track buffer</a>.</li>
-                </ol>
-              </li>
-              <li>
-                <p>For each text track in the <a href="#init-segment">initialization segment</a>, run following steps:</p>
-                <ol>
-                  <li>Let <var>text byte stream track ID</var> be the
-                    <a href="#track-id">Track ID</a> for the current track being processed.</li>
-                  <li>Let <var>text language</var> be a BCP 47 language tag for the language specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no language info is present.</li>
-                  <li>If <var>text language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>text language</var>.</li>
-                  <li>Let <var>text label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no label info is present.</li>
-                  <li>Let <var>text kinds</var> be a sequence of kind strings specified in the
-                    <a href="#init-segment">initialization segment</a> for this track or a sequence with a single empty string element in it if no kind information is provided.</li>
-                  <li>For each value in <var>text kinds</var>, run the following steps:
-                    <ol>
-                      <li>Let <var>current text kind</var> equal the value from <var>text kinds</var> for this iteration of the loop.</li>
-                      <li>
-                        Let <var>new text track</var> be a new <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object.</li>
-                      <li>Generate a unique ID and assign it to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-id">id</a></code> property on <var>new text track</var>.</li>
-                      <li>Assign <var>text language</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-language">language</a></code> property on <var>new text track</var>.</li>
-                      <li>Assign <var>text label</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-label">label</a></code> property on <var>new text track</var>.</li>
-                      <li>Assign <var>current text kind</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-kind">kind</a></code> property on <var>new text track</var>.</li>
-                      <li>Populate the remaining properties on <var>new text track</var> with the appropriate information from the <a href="#init-segment">initialization segment</a>.
-                      </li>
-                      <li>
-                        If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a></code> property on <var>new text track</var> equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or
-                        <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code>, then set <var>active track flag</var> to true.
-                      </li>
-                      <li>Add <var>new text track</var> to the <code><a href="#dom-sourcebuffer-texttracks">textTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note47"><span>Note</span></div>
-                          <p class="">
-                            This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to <var>new text track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> object referenced by the <code><a href="#dom-sourcebuffer-texttracks">textTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
-                          </p>
-                        </div>
-                      </li>
-                      <li>Add <var>new text track</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-texttracks">textTracks</a></code> attribute on the HTMLMediaElement.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note48"><span>Note</span></div>
-                          <p class="">
-                            This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to <var>new text track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> object referenced by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-texttracks">textTracks</a></code> attribute on the HTMLMediaElement.
-                          </p>
-                        </div>
-                      </li>
-                    </ol>
-                  </li>
-                  <li>Create a new <a href="#track-buffer">track buffer</a> to store <a href="#coded-frame">coded frames</a> for this track.</li>
-                  <li>Add the <a href="#track-description">track description</a> for this track to the <a href="#track-buffer">track buffer</a>.</li>
-                </ol>
-              </li>
-              <li>If <var>active track flag</var> equals true, then run the following steps:
-                <ol>
-                  <li>Add this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-                  <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code></li>
-                </ol>
-              </li>
-              <li>Set <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> to true.</li>
-            </ol>
-          </li>
-          <li>
-            <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>, then run the following steps:</p>
-            <ol>
-              <li>
-                If one or more objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> have <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> set to false, then abort these steps.</li>
-              <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note49"><span>Note</span></div>
-                  <p class="">
-                    Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement. This particular transition should trigger HTMLMediaElement logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#eventdef-media-loadedmetadata">loadedmetadata</a></code> at the media element.
-                  </p>
-                </div>
-              </li>
-            </ol>
-          </li>
-          <li>
-            If the <var>active track flag</var> equals true and the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than
-            <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note50"><span>Note</span></div>
-              <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-            </div>
-          </li>
-        </ol>
-      </section>
+                          <ol>
+                            <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-videotrack-selected">selected</a></code> property on <var>new video track</var> to true.</li>
+                            <li>Set <var>active track flag</var> to true.</li>
+                          </ol>
+                        </li>
+                        <li>Add <var>new video track</var> to the <code><a href="#dom-sourcebuffer-videotracks">videoTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        <div class="note" id="issue-container-generatedID-44"><div role="heading" class="note-title marker" id="h-note-44" aria-level="5"><span>Note</span></div><p class="">
+                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  <var>new video track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> object referenced by the <code><a href="#dom-sourcebuffer-videotracks">videoTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        </p></div>
+                        </li>
+                        <li>Add <var>new video track</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code> attribute on the HTMLMediaElement.
+                        <div class="note" id="issue-container-generatedID-45"><div role="heading" class="note-title marker" id="h-note-45" aria-level="5"><span>Note</span></div><p class="">
+                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-mediatracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  <var>new video track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotracklist-videotracklist">VideoTrackList</a></code> object referenced by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-videotracks">videoTracks</a></code> attribute on the HTMLMediaElement.
+                        </p></div>
+                        </li>
+                      </ol>
+                    </li>
+                    <li>Create a new <a href="#track-buffer">track buffer</a> to store <a href="#coded-frame">coded frames</a> for this track.</li>
+                    <li>Add the <a href="#track-description">track description</a> for this track to the <a href="#track-buffer">track buffer</a>.</li>
+                  </ol>
+                </li>
+                <li>
+                  <p>For each text track in the <a href="#init-segment">initialization segment</a>, run following steps:</p>
+                  <ol>
+                    <li>Let <var>text byte stream track ID</var> be the
+                      <a href="#track-id">Track ID</a> for the current track being processed.</li>
+                    <li>Let <var>text language</var> be a BCP 47 language tag for the language
+                      specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no
+                      language info is present.</li>
+                    <li>If <var>text language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>text language</var>.</li>
+                    <li>Let <var>text label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no
+                      label info is present.</li>
+                    <li>Let <var>text kinds</var> be a sequence of kind strings specified in the
+                      <a href="#init-segment">initialization segment</a> for this track
+                      or a sequence with a single empty string element in it
+                      if no kind information is provided.</li>
+                    <li>For each value in <var>text kinds</var>, run the following steps:
+                      <ol>
+                        <li>Let <var>current text kind</var> equal the value from <var>text kinds</var>
+                          for this iteration of the loop.</li>
+                        <li>
+                          Let <var>new text track</var> be a new <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> object.</li>
+                        <li>Generate a unique ID and assign it to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-id">id</a></code> property on <var>new text track</var>.</li>
+                        <li>Assign <var>text language</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-language">language</a></code>
+                          property on <var>new text track</var>.</li>
+                        <li>Assign <var>text label</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-label">label</a></code>
+                          property on <var>new text track</var>.</li>
+                        <li>Assign <var>current text kind</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-kind">kind</a></code>
+                          property on <var>new text track</var>.</li>
+                        <li>Populate the remaining properties on <var>new text track</var> with the
+                          appropriate information from the <a href="#init-segment">initialization segment</a>.
+                        </li><li>
+                          If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrack-mode">mode</a></code> property on <var>new text track</var> equals <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-showing">"showing"</a></code> or
+                          <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttrackmode-hidden">"hidden"</a></code>, then set <var>active track flag</var> to true.
+                        </li>
+                        <li>Add <var>new text track</var> to the <code><a href="#dom-sourcebuffer-texttracks">textTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        <div class="note" id="issue-container-generatedID-46"><div role="heading" class="note-title marker" id="h-note-46" aria-level="5"><span>Note</span></div><p class="">
+                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  <var>new text track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> object referenced by the <code><a href="#dom-sourcebuffer-texttracks">textTracks</a></code> attribute on this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object.
+                        </p></div>
+                        </li>
+                        <li>Add <var>new text track</var> to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-texttracks">textTracks</a></code> attribute on the HTMLMediaElement.
+                        <div class="note" id="issue-container-generatedID-47"><div role="heading" class="note-title marker" id="h-note-47" aria-level="5"><span>Note</span></div><p class="">
+                          This should trigger <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to fire a <a href="https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-texttracklist-onaddtrack">addtrack</a></code>, that does not bubble and is not cancelable, and that uses the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#trackevent-trackevent">TrackEvent</a></code> interface, with the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-trackevent-track">track</a></code> attribute initialized to  <var>new text track</var>, at the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttracklist-texttracklist">TextTrackList</a></code> object referenced by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-texttracks">textTracks</a></code> attribute on the HTMLMediaElement.
+                        </p></div>
+                        </li>
+                      </ol>
+                    </li>
+                    <li>Create a new <a href="#track-buffer">track buffer</a> to store <a href="#coded-frame">coded frames</a> for this track.</li>
+                    <li>Add the <a href="#track-description">track description</a> for this track to the <a href="#track-buffer">track buffer</a>.</li>
+                  </ol>
+                </li>
+                <li>If <var>active track flag</var> equals true, then run the following steps:
+                  <ol>
+                    <li>Add this <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> to <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
+                    <li><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> at <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code></li>
+                  </ol>
+                </li>
+                <li>Set <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> to true.</li>
+              </ol>
+            </li>
+            <li>Set <var><a href="#pending-init-segment-for-changetype-flag">pending initialization segment for changeType flag</a></var> to false.</li>
+            <li>
+              <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_nothing">HAVE_NOTHING</a></code>, then run the following steps:</p>
+              <ol>
+                <li>
+                  If one or more objects in <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> have <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> set to false, then abort
+                  these steps.</li>
+                <li>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
+                <div class="note" id="issue-container-generatedID-48"><div role="heading" class="note-title marker" id="h-note-48" aria-level="5"><span>Note</span></div><p class="">
+                  Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement. This particular transition should trigger HTMLMediaElement logic to <a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to <a href="https://www.w3.org/TR/html51/infrastructure.html#fire">fire a simple event</a> named <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#eventdef-media-loadedmetadata">loadedmetadata</a></code> at the media element.
+                </p></div>
+                </li>
+              </ol>
+            </li>
+            <li>
+              If the <var>active track flag</var> equals true and the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is greater than
+              <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
+            <div class="note" id="issue-container-generatedID-49"><div role="heading" class="note-title marker" id="h-note-49" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+            </li>
+          </ol>
+        </section>
 
-      <section id="sourcebuffer-coded-frame-processing" typeof="bibo:Chapter" resource="#sourcebuffer-coded-frame-processing" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-coded-frame-processing" resource="#h-sourcebuffer-coded-frame-processing"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.8 </span>Coded Frame Processing</span>
-        </h4>
-        <p>When complete <a href="#coded-frame">coded frames</a> have been parsed by the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> then the following steps are run:</p>
-        <ol>
-          <li>
-            <p>For each <a href="#coded-frame">coded frame</a> in the <a href="#media-segment">media segment</a> run the following steps:</p>
-            <ol>
-              <li><i>Loop Top: </i>
-                <dl class="switch">
-                  <dt>If <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true:</dt>
-                  <dd>
-                    <ol>
-                      <li>Let <var>presentation timestamp</var> equal 0.</li>
-                      <li>Let <var>decode timestamp</var> equal 0.</li>
+        <section id="sourcebuffer-coded-frame-processing">
+          <h4 id="x3-5-8-coded-frame-processing"><span class="secno">3.5.8 </span>Coded Frame Processing</h4>
+          <p>When complete <a href="#coded-frame">coded frames</a> have been parsed by the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> then the following steps are run:</p>
+          <ol>
+            <li>
+              <p>For each <a href="#coded-frame">coded frame</a> in the <a href="#media-segment">media segment</a> run the following steps:</p>
+              <ol>
+                <li><i>Loop Top: </i><dl class="switch">
+                    <dt>If <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true:</dt>
+                    <dd>
+                      <ol>
+                        <li>Let <var>presentation timestamp</var> equal 0.</li>
+                        <li>Let <var>decode timestamp</var> equal 0.</li>
+                      </ol>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <ol>
+                        <li>Let <var>presentation timestamp</var> be a double precision floating point representation of the coded frame's <a href="#presentation-timestamp">presentation timestamp</a> in seconds.
+                          <div class="note" id="issue-container-generatedID-50"><div role="heading" class="note-title marker" id="h-note-50" aria-level="5"><span>Note</span></div><p class="">Special processing may be needed to determine the presentation and decode timestamps for timed text frames since this information may not be explicitly
+                            present in the underlying format or may be dependent on the order of the frames. Some metadata text tracks, like MPEG2-TS PSI data, may only have implied timestamps.
+                            Format specific rules for these situations <em class="rfc2119" title="SHOULD">SHOULD</em> be in the <a href="#byte-stream-format-specs">byte stream format specifications</a> or in separate extension specifications.</p></div>
+                        </li>
+                        <li>Let <var>decode timestamp</var> be a double precision floating point representation of the coded frame's decode timestamp in seconds.
+                          <div class="note" id="issue-container-generatedID-51"><div role="heading" class="note-title marker" id="h-note-51" aria-level="5"><span>Note</span></div><p class="">Implementations don't have to internally store timestamps in a double precision floating point representation. This
+                            representation is used here because it is the represention for timestamps in the HTML spec. The intention here is to make the
+                            behavior clear without adding unnecessary complexity to the algorithm to deal with the fact that adding a timestampOffset may
+                            cause a timestamp rollover in the underlying timestamp representation used by the byte stream format. Implementations can use any
+                            internal timestamp representation they wish, but the addition of timestampOffset <em class="rfc2119" title="SHOULD">SHOULD</em> behave in a similar manner to what would happen
+                            if a double precision floating point representation was used.
+                          </p></div>
+                        </li>
                     </ol>
-                  </dd>
-                  <dt>Otherwise:</dt>
-                  <dd>
-                    <ol>
-                      <li>Let <var>presentation timestamp</var> be a double precision floating point representation of the coded frame's <a href="#presentation-timestamp">presentation timestamp</a> in seconds.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note51"><span>Note</span></div>
-                          <p class="">Special processing may be needed to determine the presentation and decode timestamps for timed text frames since this information may not be explicitly present in the underlying format or may be dependent on the order of the frames. Some metadata text tracks, like MPEG2-TS PSI data, may only have implied timestamps. Format specific rules for these situations <em class="rfc2119" title="SHOULD">SHOULD</em> be in the <a href="#byte-stream-format-specs">byte stream format specifications</a> or in separate extension specifications.</p>
-                        </div>
-                      </li>
-                      <li>Let <var>decode timestamp</var> be a double precision floating point representation of the coded frame's decode timestamp in seconds.
-                        <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note52"><span>Note</span></div>
-                          <p class="">Implementations don't have to internally store timestamps in a double precision floating point representation. This representation is used here because it is the represention for timestamps in the HTML spec. The intention here is to make the behavior clear without adding unnecessary complexity to the algorithm to deal with the fact that adding a timestampOffset may cause a timestamp rollover in the underlying timestamp representation used by the byte stream format. Implementations can use any internal timestamp representation they wish, but the addition of timestampOffset <em class="rfc2119" title="SHOULD">SHOULD</em> behave in a similar manner to what would happen if a double precision floating point representation was used.
-                          </p>
-                        </div>
-                      </li>
-                    </ol>
-                  </dd>
-                </dl>
-              </li>
-              <li>Let <var>frame duration</var> be a double precision floating point representation of the <a href="#coded-frame-duration">coded frame's duration</a> in seconds.</li>
-              <li>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> and <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> is set, then run the following steps:
-                <ol>
-                  <li>Set <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> equal to <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> - <var>presentation timestamp</var>.</li>
-                  <li>Set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> equal to <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var>.</li>
-                  <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
-                  <li>Unset <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var>.</li>
-                </ol>
-              </li>
-              <li>
-                <p>If <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> is not 0, then run the following steps:</p>
-                <ol>
-                  <li>Add <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> to the <var>presentation timestamp</var>.</li>
-                  <li>Add <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> to the <var>decode timestamp</var>.</li>
-                </ol>
-              </li>
-              <li>Let <var>track buffer</var> equal the <a href="#track-buffer">track buffer</a> that the coded frame will be added to.</li>
-              <li>
-                <dl class="switch">
-                  <dt>If <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> is set and <var>decode timestamp</var> is less than
+                    </dd>
+                  </dl>
+                </li>
+                <li>Let <var>frame duration</var> be a double precision floating point representation of the <a href="#coded-frame-duration">coded frame's duration</a> in seconds.</li>
+                <li>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code> and <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> is set, then run the following steps:
+                  <ol>
+                    <li>Set <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> equal to <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> - <var>presentation timestamp</var>.</li>
+                    <li>Set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> equal to <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var>.</li>
+                    <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
+                    <li>Unset <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var>.</li>
+                  </ol>
+                </li>
+                <li>
+                  <p>If <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> is not 0, then run the following steps:</p>
+                  <ol>
+                    <li>Add <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> to the <var>presentation timestamp</var>.</li>
+                    <li>Add <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> to the <var>decode timestamp</var>.</li>
+                  </ol>
+                </li>
+                <li>Let <var>track buffer</var> equal the <a href="#track-buffer">track buffer</a> that the coded frame will be added to.</li>
+                <li>
+                  <dl class="switch">
+                    <dt>If <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> is set and <var>decode timestamp</var> is less than
                       <var><a href="#last-decode-timestamp">last decode timestamp</a></var>:</dt>
-                  <dd>OR</dd>
-                  <dt>If <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> is set and the difference between <var>decode timestamp</var> and <var><a href="#last-decode-timestamp">last decode timestamp</a></var>
+                    <dd>OR</dd>
+                    <dt>If <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> is set and the difference between <var>decode timestamp</var> and <var><a href="#last-decode-timestamp">last decode timestamp</a></var>
                       is greater than 2 times <var><a href="#last-frame-duration">last frame duration</a></var>:</dt>
-                  <dd>
-                    <ol>
-                      <li>
-                        <dl class="switch">
-                          <dt>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.segments">"segments"</a></code>:</dt>
-                          <dd>Set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> to <var>presentation timestamp</var>.</dd>
-                          <dt>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>:</dt>
-                          <dd>Set <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> equal to the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>.</dd>
-                        </dl>
-                      </li>
-                      <li>Unset the <var><a href="#last-decode-timestamp">last decode timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
-                      <li>Unset the <var><a href="#last-frame-duration">last frame duration</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
-                      <li>Unset the <var><a href="#highest-end-timestamp">highest end timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
-                      <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
-                      <li>Jump to the <i>Loop Top</i> step above to restart processing of the current <a href="#coded-frame">coded frame</a>.</li>
-                    </ol>
-                  </dd>
-                  <dt>Otherwise:</dt>
-                  <dd>Continue.</dd>
-                </dl>
-              </li>
-              <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
-              <li>If <var>presentation timestamp</var> is less than <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code>, then set the <var><a href="#need-RAP-flag">need random access point flag</a></var> to true, drop the coded frame, and jump to the top of the loop to start processing the next coded frame.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note53"><span>Note</span></div>
-                  <p class="">Some implementations <em class="rfc2119" title="MAY">MAY</em> choose to collect some of these coded frames with <var>presentation timestamp</var> less than <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> and use them to generate a splice at the first coded frame that has a <a href="#presentation-timestamp">presentation timestamp</a> greater than or equal to <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> even if that frame is not a <a href="#random-access-point">random access point</a>. Supporting this requires multiple decoders or faster than real-time decoding so for now this behavior will not be a normative requirement.
-                  </p>
-                </div>
-              </li>
-              <li>If <var>frame end timestamp</var> is greater than <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code>, then set the <var><a href="#need-RAP-flag">need random access point flag</a></var> to true, drop the coded frame, and jump to the top of the loop to start processing the next coded frame.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note54"><span>Note</span></div>
-                  <p class="">Some implementations <em class="rfc2119" title="MAY">MAY</em> choose to collect coded frames with <var>presentation timestamp</var> less than <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> and <var>frame end timestamp</var> greater than <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> and use them to generate a splice across the portion of the collected coded frames within the append window at time of collection, and the beginning portion of later processed frames which only partially overlap the end of the collected coded frames. Supporting this requires multiple decoders or faster than real-time decoding so for now this behavior will not be a normative requirement. In conjunction with collecting coded frames that span <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code>, implementations <em class="rfc2119" title="MAY">MAY</em> thus support gapless audio splicing.
-                  </p>
-                </div>
-              </li>
-              <li>If the <var><a href="#need-RAP-flag">need random access point flag</a></var> on <var>track buffer</var> equals true, then run the following steps:
-                <ol>
-                  <li>If the coded frame is not a <a href="#random-access-point">random access point</a>, then drop the coded frame and jump to the top of the loop to start processing the next coded frame.</li>
-                  <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on <var>track buffer</var> to false.</li>
-                </ol>
-              </li>
-              <li>Let <var>spliced audio frame</var> be an unset variable for holding audio splice information</li>
-              <li>Let <var>spliced timed text frame</var> be an unset variable for holding timed text splice information</li>
-              <li>If <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> is unset and <var>presentation timestamp</var> falls within the <a href="#presentation-interval">presentation interval</a> of a <a href="#coded-frame">coded frame</a> in <var>track buffer</var>, then run the following steps:
-                <ol>
-                  <li>Let <var>overlapped frame</var> be the <a href="#coded-frame">coded frame</a> in <var>track buffer</var> that matches the condition above.</li>
-                  <li>
-                    <dl class="switch">
-                      <dt>If <var>track buffer</var> contains audio <a href="#coded-frame">coded frames</a>:</dt>
-                      <dd>Run the <a href="#sourcebuffer-audio-splice-frame-algorithm">audio splice frame algorithm</a> and if a splice frame is returned, assign it to <var>spliced audio frame</var>.</dd>
-                      <dt>If <var>track buffer</var> contains video <a href="#coded-frame">coded frames</a>:</dt>
-                      <dd>
-                        <ol>
-                          <li>Let <var>remove window timestamp</var> equal the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a> plus 1 microsecond.</li>
-                          <li>If the <var>presentation timestamp</var> is less than the <var>remove window timestamp</var>, then remove <var>overlapped frame</var> from <var>track buffer</var>.
-                            <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note55"><span>Note</span></div>
-                              <p class="">
-                                This is to compensate for minor errors in frame timestamp computations that can appear when converting back and forth between double precision floating point numbers and rationals. This tolerance allows a frame to replace an existing one as long as it is within 1 microsecond of the existing frame's start time. Frames that come slightly before an existing frame are handled by the removal step below.
-                              </p>
-                            </div>
-                          </li>
-                        </ol>
-                      </dd>
-                      <dt>If <var>track buffer</var> contains timed text <a href="#coded-frame">coded frames</a>:</dt>
-                      <dd>Run the <a href="#sourcebuffer-text-splice-frame-algorithm">text splice frame algorithm</a> and if a splice frame is returned, assign it to <var>spliced timed text frame</var>.</dd>
-                    </dl>
-                  </li>
-                </ol>
-              </li>
-              <li>Remove existing coded frames in <var>track buffer</var>:
-                <dl class="switch">
-                  <dt>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is not set:</dt>
-                  <dd>Remove all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> that have a <a href="#presentation-timestamp">presentation timestamp</a> greater than or equal to
-                    <var>presentation timestamp</var> and less than <var>frame end timestamp</var>.</dd>
-                  <dt>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is set and less than or equal to <var>presentation timestamp</var>:</dt>
-                  <dd>Remove all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> that have a <a href="#presentation-timestamp">presentation timestamp</a> greater than or equal to <var><a href="#highest-end-timestamp">highest end timestamp</a></var> and less than <var>frame end timestamp</var></dd>
-                </dl>
-              </li>
-              <li>Remove all possible decoding dependencies on the <a href="#coded-frame">coded frames</a> removed in the previous two steps by removing all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> between those frames removed in the previous two steps and the next
-                <a href="#random-access-point">random access point</a> after those removed frames.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note56"><span>Note</span></div>
-                  <p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative estimate of the decoding dependencies since it assumes all frames between the removed frames and the next random access point depended on the frames that were removed.
-                  </p>
-                </div>
-              </li>
-              <li>
-                <dl class="switch">
-                  <dt>If <var>spliced audio frame</var> is set:</dt>
-                  <dd>Add <var>spliced audio frame</var> to the <var>track buffer</var>.</dd>
-                  <dt>If <var>spliced timed text frame</var> is set:</dt>
-                  <dd>Add <var>spliced timed text frame</var> to the <var>track buffer</var>.</dd>
-                  <dt>Otherwise:</dt>
-                  <dd>Add the <a href="#coded-frame">coded frame</a> with the <var>presentation timestamp</var>, <var>decode timestamp</var>, and <var>frame duration</var> to the
-                    <var>track buffer</var>.</dd>
-                </dl>
-              </li>
-              <li>Set <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> to <var>decode timestamp</var>.</li>
-              <li>Set <var><a href="#last-frame-duration">last frame duration</a></var> for <var>track buffer</var> to <var>frame duration</var>.</li>
-              <li>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is unset or <var>frame end timestamp</var> is greater than <var><a href="#highest-end-timestamp">highest end timestamp</a></var>, then set <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> to <var>frame end timestamp</var>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note57"><span>Note</span></div>
-                  <p class="">The greater than check is needed because bidirectional prediction between coded frames can cause
-                    <var>presentation timestamp</var> to not be monotonically increasing even though the decode timestamps are monotonically increasing.</p>
-                </div>
-              </li>
-              <li>If <var>frame end timestamp</var> is greater than <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>, then set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> equal to <var>frame end timestamp</var>.</li>
-              <li>If <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true, then set
-                <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> equal to <var>frame end timestamp</var>.</li>
-            </ol>
-          </li>
-          <li>
-            <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code> and the new <a href="#coded-frame">coded frames</a> cause <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to have a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> for the current playback position, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note58"><span>Note</span></div>
-              <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-            </div>
-          </li>
-          <li>
-            <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code> and the new <a href="#coded-frame">coded frames</a> cause <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to have a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and some time beyond the current playback position, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code>.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note59"><span>Note</span></div>
-              <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-            </div>
-          </li>
-          <li>
-            <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code> and the new <a href="#coded-frame">coded frames</a> cause <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to have a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and <a href="#enough-data">enough data to ensure uninterrupted playback</a>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code>.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note60"><span>Note</span></div>
-              <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-            </div>
-          </li>
-          <li>If the <a href="#media-segment">media segment</a> contains data beyond the current <code><a href="#dom-mediasource-duration">duration</a></code>, then run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the maximum of the current duration and the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>.</li>
-        </ol>
-      </section>
+                    <dd>
+                      <ol>
+                        <li>
+                          <dl class="switch">
+                            <dt>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.segments">"segments"</a></code>:</dt>
+                            <dd>Set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> to <var>presentation timestamp</var>.</dd>
+                            <dt>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.sequence">"sequence"</a></code>:</dt>
+                            <dd>Set <var><a href="#sourcebuffer-group-start-timestamp">group start timestamp</a></var> equal to the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>.</dd>
+                          </dl>
+                        </li>
+                        <li>Unset the <var><a href="#last-decode-timestamp">last decode timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
+                        <li>Unset the <var><a href="#last-frame-duration">last frame duration</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
+                        <li>Unset the <var><a href="#highest-end-timestamp">highest end timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
+                        <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
+                        <li>Jump to the <i>Loop Top</i> step above to restart processing of the current <a href="#coded-frame">coded frame</a>.</li>
+                      </ol>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>Continue.</dd>
+                  </dl>
+                </li>
+                <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
+                <li>If <var>presentation timestamp</var> is less than <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code>, then set the <var><a href="#need-RAP-flag">need random access point flag</a></var> to true, drop the
+                  coded frame, and jump to the top of the loop to start processing the next coded frame.
+                  <div class="note" id="issue-container-generatedID-52"><div role="heading" class="note-title marker" id="h-note-52" aria-level="5"><span>Note</span></div><p class="">Some implementations <em class="rfc2119" title="MAY">MAY</em> choose to collect some of these coded frames with <var>presentation timestamp</var> less than <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> and use them
+                    to generate a splice at the first coded frame that has a <a href="#presentation-timestamp">presentation timestamp</a> greater than or equal to <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code> even if
+                    that frame is not a <a href="#random-access-point">random access point</a>. Supporting this requires multiple decoders or faster than real-time decoding so for now
+                    this behavior will not be a normative requirement.
+                  </p></div>
+                </li>
+                <li>If <var>frame end timestamp</var> is greater than <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code>, then set the <var><a href="#need-RAP-flag">need random access point flag</a></var> to true, drop the
+                  coded frame, and jump to the top of the loop to start processing the next coded frame.
+                  <div class="note" id="issue-container-generatedID-53"><div role="heading" class="note-title marker" id="h-note-53" aria-level="5"><span>Note</span></div><p class="">Some implementations <em class="rfc2119" title="MAY">MAY</em> choose to collect coded frames with <var>presentation timestamp</var> less than <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> and <var>frame end timestamp</var> greater than <code><a href="#dom-sourcebuffer-appendwindowend">appendWindowEnd</a></code> and use them
+                  to generate a splice across the portion of the collected coded frames within the append window at time of collection, and the beginning portion of later processed frames which only partially overlap the end of the collected coded frames.
+                    Supporting this requires multiple decoders or faster than real-time decoding so for now
+                    this behavior will not be a normative requirement.
+                    In conjunction with collecting coded frames that span <code><a href="#dom-sourcebuffer-appendwindowstart">appendWindowStart</a></code>, implementations <em class="rfc2119" title="MAY">MAY</em> thus support gapless audio splicing.
+                  </p></div>
+                </li>
+                <li>If the <var><a href="#need-RAP-flag">need random access point flag</a></var> on <var>track buffer</var> equals true, then run the following steps:
+                  <ol>
+                    <li>If the coded frame is not a <a href="#random-access-point">random access point</a>, then drop the coded frame and jump to the top of the loop to start
+                      processing the next coded frame.</li>
+                    <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on <var>track buffer</var> to false.</li>
+                  </ol>
+                </li>
+                <li>Let <var>spliced audio frame</var> be an unset variable for holding audio splice information</li>
+                <li>Let <var>spliced timed text frame</var> be an unset variable for holding timed text splice information</li>
+                <li>If <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> is unset and <var>presentation timestamp</var> falls within the <a href="#presentation-interval">presentation interval</a> of a <a href="#coded-frame">coded frame</a> in <var>track buffer</var>, then run the following steps:
+                  <ol>
+                    <li>Let <var>overlapped frame</var> be the <a href="#coded-frame">coded frame</a> in <var>track buffer</var> that matches the condition above.</li>
+                    <li>
+                      <dl class="switch">
+                        <dt>If <var>track buffer</var> contains audio <a href="#coded-frame">coded frames</a>:</dt>
+                        <dd>Run the <a href="#sourcebuffer-audio-splice-frame-algorithm">audio splice frame algorithm</a> and if a splice frame is returned, assign it to <var>spliced audio frame</var>.</dd>
+                        <dt>If <var>track buffer</var> contains video <a href="#coded-frame">coded frames</a>:</dt>
+                        <dd>
+                          <ol>
+                            <li>Let <var>remove window timestamp</var> equal the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a> plus 1 microsecond.</li>
+                            <li>If the <var>presentation timestamp</var> is less than the <var>remove window timestamp</var>, then remove <var>overlapped frame</var> from <var>track buffer</var>.
+                              <div class="note" id="issue-container-generatedID-54"><div role="heading" class="note-title marker" id="h-note-54" aria-level="5"><span>Note</span></div><p class="">
+                                This is to compensate for minor errors in frame timestamp computations that can appear when converting back and forth between double precision
+                                floating point numbers and rationals. This tolerance allows a frame to replace an existing one as long as it is within 1 microsecond of the existing
+                                frame's start time. Frames that come slightly before an existing frame are handled by the removal step below.
+                              </p></div>
+                            </li>
+                          </ol>
+                        </dd>
+                        <dt>If <var>track buffer</var> contains timed text <a href="#coded-frame">coded frames</a>:</dt>
+                        <dd>Run the <a href="#sourcebuffer-text-splice-frame-algorithm">text splice frame algorithm</a> and if a splice frame is returned, assign it to <var>spliced timed text frame</var>.</dd>
+                      </dl>
+                    </li>
+                  </ol>
+                </li>
+                <li>Remove existing coded frames in <var>track buffer</var>:
+                  <dl class="switch">
+                    <dt>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is not set:</dt>
+                    <dd>Remove all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> that have a <a href="#presentation-timestamp">presentation timestamp</a> greater than or equal to
+                      <var>presentation timestamp</var> and less than <var>frame end timestamp</var>.</dd>
+                    <dt>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is set and less than or equal to <var>presentation timestamp</var>:</dt>
+                    <dd>Remove all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> that have a <a href="#presentation-timestamp">presentation timestamp</a> greater than
+                      or equal to <var><a href="#highest-end-timestamp">highest end timestamp</a></var> and less than <var>frame end timestamp</var></dd>
+                  </dl>
+                </li>
+                <li>Remove all possible decoding dependencies on the <a href="#coded-frame">coded frames</a> removed in the previous two steps
+                  by removing all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> between those frames removed in the previous two steps and the next
+                  <a href="#random-access-point">random access point</a> after those removed frames.
+                  <div class="note" id="issue-container-generatedID-55"><div role="heading" class="note-title marker" id="h-note-55" aria-level="5"><span>Note</span></div><p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative
+                    estimate of the decoding dependencies since it assumes all frames between the removed frames and the next random access point
+                    depended on the frames that were removed.
+                  </p></div>
+                </li>
+                <li>
+                  <dl class="switch">
+                    <dt>If <var>spliced audio frame</var> is set:</dt>
+                    <dd>Add <var>spliced audio frame</var> to the <var>track buffer</var>.</dd>
+                    <dt>If <var>spliced timed text frame</var> is set:</dt>
+                    <dd>Add <var>spliced timed text frame</var> to the <var>track buffer</var>.</dd>
+                    <dt>Otherwise:</dt>
+                    <dd>Add the <a href="#coded-frame">coded frame</a> with the <var>presentation timestamp</var>, <var>decode timestamp</var>, and <var>frame duration</var> to the
+                      <var>track buffer</var>.</dd>
+                  </dl>
+                </li><li>Set <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for <var>track buffer</var> to <var>decode timestamp</var>.</li>
+                <li>Set <var><a href="#last-frame-duration">last frame duration</a></var> for <var>track buffer</var> to <var>frame duration</var>.</li>
+                <li>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is unset or <var>frame end timestamp</var> is greater
+                  than <var><a href="#highest-end-timestamp">highest end timestamp</a></var>, then set <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var>
+                  to <var>frame end timestamp</var>.
+                  <div class="note" id="issue-container-generatedID-56"><div role="heading" class="note-title marker" id="h-note-56" aria-level="5"><span>Note</span></div><p class="">The greater than check is needed because bidirectional prediction between coded frames can cause
+                    <var>presentation timestamp</var> to not be monotonically increasing even though the decode timestamps are monotonically increasing.</p></div>
+                </li>
+                <li>If <var>frame end timestamp</var> is greater than <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>,
+                  then set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> equal to <var>frame end timestamp</var>.</li>
+                <li>If <var><a href="#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> equals true, then set
+                  <code><a href="#dom-sourcebuffer-timestampoffset">timestampOffset</a></code> equal to <var>frame end timestamp</var>.</li>
+              </ol>
+            </li>
+            <li>
+              <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code> and the new <a href="#coded-frame">coded frames</a> cause <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to have a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> for the current playback position, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.</p>
+              <div class="note" id="issue-container-generatedID-57"><div role="heading" class="note-title marker" id="h-note-57" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+            </li>
+            <li>
+              <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code> and the new <a href="#coded-frame">coded frames</a> cause <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to have a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and some time beyond the current playback position, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code>.</p>
+              <div class="note" id="issue-container-generatedID-58"><div role="heading" class="note-title marker" id="h-note-58" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+            </li>
+            <li>
+              <p>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute is <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_future_data">HAVE_FUTURE_DATA</a></code> and the new <a href="#coded-frame">coded frames</a> cause <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> to have a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> that includes the current playback position and <a href="#enough-data">enough data to ensure uninterrupted playback</a>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_enough_data">HAVE_ENOUGH_DATA</a></code>.</p>
+              <div class="note" id="issue-container-generatedID-59"><div role="heading" class="note-title marker" id="h-note-59" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+            </li>
+            <li>If the <a href="#media-segment">media segment</a> contains data beyond the current <code><a href="#dom-mediasource-duration">duration</a></code>, then run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the maximum of the current duration and the <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>.</li>
+          </ol>
+        </section>
 
-      <section id="sourcebuffer-coded-frame-removal" typeof="bibo:Chapter" resource="#sourcebuffer-coded-frame-removal" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-coded-frame-removal" resource="#h-sourcebuffer-coded-frame-removal"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.9 </span>Coded Frame Removal Algorithm</span>
-        </h4>
-        <p>Follow these steps when <a href="#coded-frame">coded frames</a> for a specific time range need to be removed from the SourceBuffer:</p>
-        <ol>
-          <li>Let <var>start</var> be the starting <a href="#presentation-timestamp">presentation timestamp</a> for the removal range.</li>
-          <li>Let <var>end</var> be the end <a href="#presentation-timestamp">presentation timestamp</a> for the removal range. </li>
-          <li>
-            <p>For each <a href="#track-buffer">track buffer</a> in this source buffer, run the following steps:</p>
-            <ol>
-              <li>Let <var>remove end timestamp</var> be the current value of <code><a href="#dom-mediasource-duration">duration</a></code></li>
-              <li>
-                <p>If this <a href="#track-buffer">track buffer</a> has a <a href="#random-access-point">random access point</a> timestamp that is greater than or equal to
-                  <var>end</var>, then update <var>remove end timestamp</var> to that random access point timestamp.</p>
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note61"><span>Note</span></div>
-                  <p class="">Random access point timestamps can be different across tracks because the dependencies between <a href="#coded-frame">coded frames</a> within a track are usually different than the dependencies in another track.</p>
-                </div>
-              </li>
-              <li>Remove all media data, from this <a href="#track-buffer">track buffer</a>, that contain starting timestamps greater than or equal to <var>start</var> and less than the <var>remove end timestamp</var>.
+        <section id="sourcebuffer-coded-frame-removal">
+          <h4 id="x3-5-9-coded-frame-removal-algorithm"><span class="secno">3.5.9 </span>Coded Frame Removal Algorithm</h4>
+          <p>Follow these steps when <a href="#coded-frame">coded frames</a> for a specific time range need to be removed from the SourceBuffer:</p>
+          <ol>
+            <li>Let <var>start</var> be the starting <a href="#presentation-timestamp">presentation timestamp</a> for the removal range.</li>
+            <li>Let <var>end</var> be the end <a href="#presentation-timestamp">presentation timestamp</a> for the removal range. </li>
+            <li><p>For each <a href="#track-buffer">track buffer</a> in this source buffer, run the following steps:</p>
+              <ol>
+                <li>Let <var>remove end timestamp</var> be the current value of <code><a href="#dom-mediasource-duration">duration</a></code></li>
+                <li>
+                  <p>If this <a href="#track-buffer">track buffer</a> has a <a href="#random-access-point">random access point</a> timestamp that is greater than or equal to
+                    <var>end</var>, then update <var>remove end timestamp</var> to that random access point timestamp.</p>
+                  <div class="note" id="issue-container-generatedID-60"><div role="heading" class="note-title marker" id="h-note-60" aria-level="5"><span>Note</span></div><p class="">Random access point timestamps can be different across tracks because the dependencies between <a href="#coded-frame">coded frames</a> within a
+                    track are usually different than the dependencies in another track.</p></div>
+                </li>
+                <li>Remove all media data, from this <a href="#track-buffer">track buffer</a>, that contain starting timestamps greater than or equal to <var>start</var> and less than the <var>remove end timestamp</var>.
                 <ol>
-                  <li>
-                    <p>For each removed frame, if the frame has a <a href="#decode-timestamp">decode timestamp</a> equal to the <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for the frame's track, run the following steps:</p>
+                  <li><p>For each removed frame, if the frame has a <a href="#decode-timestamp">decode timestamp</a> equal to the <var><a href="#last-decode-timestamp">last decode timestamp</a></var> for the frame's track, run the following steps:</p>
                     <dl class="switch">
                       <dt>If <code><a href="#dom-sourcebuffer-mode">mode</a></code> equals <code><a href="#idl-def-AppendMode.segments">"segments"</a></code>:</dt>
                       <dd>Set <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> to <a href="#presentation-timestamp">presentation timestamp</a>.</dd>
@@ -3224,72 +2853,63 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <li>Unset the <var><a href="#highest-end-timestamp">highest end timestamp</a></var> on all <a href="#track-buffer">track buffers</a>.</li>
                   <li>Set the <var><a href="#need-RAP-flag">need random access point flag</a></var> on all <a href="#track-buffer">track buffers</a> to true.</li>
                 </ol>
-              </li>
-              <li>Remove all possible decoding dependencies on the <a href="#coded-frame">coded frames</a> removed in the previous step by removing all <a href="#coded-frame">coded frames</a> from this <a href="#track-buffer">track buffer</a> between those frames removed in the previous step and the next
-                <a href="#random-access-point">random access point</a> after those removed frames.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note62"><span>Note</span></div>
-                  <p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative estimate of the decoding dependencies since it assumes all frames between the removed frames and the next random access point depended on the frames that were removed.
-                  </p>
-                </div>
-              </li>
-              <li>
-                <p>If this object is in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> is greater than or equal to
-                  <var>start</var> and less than the <var>remove end timestamp</var>, and <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> is greater than
-                  <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code> and stall playback.</p>
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note63"><span>Note</span></div>
-                  <p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p>
-                </div>
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note64"><span>Note</span></div>
-                  <p class="">This transition occurs because media data for the current position has been removed. Playback cannot progress until media for the
-                    <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> is appended or the <a href="#active-source-buffer-changes">selected/enabled tracks change</a>.</p>
-                </div>
-              </li>
-            </ol>
-          </li>
-          <li>If <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals true and this object is ready to accept more bytes, then set the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> to false.</li>
-        </ol>
-      </section>
+                </li>
+                <li>Remove all possible decoding dependencies on the <a href="#coded-frame">coded frames</a> removed in the previous step
+                  by removing all <a href="#coded-frame">coded frames</a> from this <a href="#track-buffer">track buffer</a> between those frames removed in the previous step and the next
+                  <a href="#random-access-point">random access point</a> after those removed frames.
+                  <div class="note" id="issue-container-generatedID-61"><div role="heading" class="note-title marker" id="h-note-61" aria-level="5"><span>Note</span></div><p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative
+                    estimate of the decoding dependencies since it assumes all frames between the removed frames and the next random access point
+                    depended on the frames that were removed.
+                  </p></div>
+                </li>
+                <li>
+                  <p>If this object is in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>, the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> is greater than or equal to
+                    <var>start</var> and less than the <var>remove end timestamp</var>, and <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> is greater than
+                    <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code> and stall playback.</p>
+                  <div class="note" id="issue-container-generatedID-62"><div role="heading" class="note-title marker" id="h-note-62" aria-level="5"><span>Note</span></div><p class="">Per <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#ready-states">HTMLMediaElement ready states</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] logic, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">HTMLMediaElement.readyState</a></code> changes may trigger events on the HTMLMediaElement.</p></div>
+                  <div class="note" id="issue-container-generatedID-63"><div role="heading" class="note-title marker" id="h-note-63" aria-level="5"><span>Note</span></div><p class="">This transition occurs because media data for the current position has been removed. Playback cannot progress until media for the
+                    <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> is appended or the <a href="#active-source-buffer-changes">selected/enabled tracks change</a>.</p></div>
+                </li>
+              </ol>
+            </li>
+            <li>If <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals true and this object is ready to accept more bytes, then set
+              the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> to false.</li>
+          </ol>
+        </section>
 
-      <section id="sourcebuffer-coded-frame-eviction" typeof="bibo:Chapter" resource="#sourcebuffer-coded-frame-eviction" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-coded-frame-eviction" resource="#h-sourcebuffer-coded-frame-eviction"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.10 </span>Coded Frame Eviction Algorithm</span>
-        </h4>
-        <p>This algorithm is run to free up space in this source buffer when new data is appended.</p>
-        <ol>
-          <li>Let <var>new data</var> equal the data that is about to be appended to this SourceBuffer.</li>
-          <li>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals false, then abort these steps.</li>
-          <li>Let <var>removal ranges</var> equal a list of presentation time ranges that can be evicted from the presentation to make room for the
-            <var>new data</var>.
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note65"><span>Note</span></div>
-              <p class="">Implementations <em class="rfc2119" title="MAY">MAY</em> use different methods for selecting <var>removal ranges</var> so web applications <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> depend on a specific behavior. The web application can use the <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> attribute to observe whether portions of the buffered data have been evicted.
-              </p>
-            </div>
-          </li>
-          <li>For each range in <var>removal ranges</var>, run the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a> with <var>start</var> and <var>end</var> equal to the removal range start and end timestamp respectively.</li>
-        </ol>
-      </section>
+        <section id="sourcebuffer-coded-frame-eviction">
+          <h4 id="x3-5-10-coded-frame-eviction-algorithm"><span class="secno">3.5.10 </span>Coded Frame Eviction Algorithm</h4>
+          <p>This algorithm is run to free up space in this source buffer when new data is appended.</p>
+          <ol>
+            <li>Let <var>new data</var> equal the data that is about to be appended to this SourceBuffer.</li>
+            <li>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals false, then abort these steps.</li>
+            <li>Let <var>removal ranges</var> equal a list of presentation time ranges that can be evicted from the presentation to make room for the
+              <var>new data</var>.
+              <div class="note" id="issue-container-generatedID-64"><div role="heading" class="note-title marker" id="h-note-64" aria-level="5"><span>Note</span></div><p class="">Implementations <em class="rfc2119" title="MAY">MAY</em> use different methods for selecting <var>removal ranges</var> so web applications <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> depend on a
+                specific behavior. The web application can use the <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> attribute to observe whether portions of the buffered data have been evicted.
+              </p></div>
+            </li>
+            <li>For each range in <var>removal ranges</var>, run the <a href="#sourcebuffer-coded-frame-removal">coded frame removal algorithm</a> with <var>start</var> and <var>end</var> equal to
+              the removal range start and end timestamp respectively.</li>
+          </ol>
+        </section>
 
-      <section id="sourcebuffer-audio-splice-frame-algorithm" typeof="bibo:Chapter" resource="#sourcebuffer-audio-splice-frame-algorithm" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-audio-splice-frame-algorithm" resource="#h-sourcebuffer-audio-splice-frame-algorithm"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.11 </span>Audio Splice Frame Algorithm</span>
-        </h4>
-        <p>Follow these steps when the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> needs to generate a splice frame for two overlapping audio
-          <a href="#coded-frame">coded frames</a>:</p>
-        <ol>
-          <li>Let <var>track buffer</var> be the <a href="#track-buffer">track buffer</a> that will contain the splice.</li>
-          <li>Let <var>new coded frame</var> be the new <a href="#coded-frame">coded frame</a>, that is being added to <var>track buffer</var>, which triggered the need for a splice.</li>
-          <li>Let <var>presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> for <var>new coded frame</var></li>
-          <li>Let <var>decode timestamp</var> be the decode timestamp for <var>new coded frame</var>.</li>
-          <li>Let <var>frame duration</var> be the <a href="#coded-frame-duration">coded frame duration</a> of <var>new coded frame</var>.</li>
-          <li>Let <var>overlapped frame</var> be the <a href="#coded-frame">coded frame</a> in <var>track buffer</var> with a <a href="#presentation-interval">presentation interval</a> that contains <var>presentation timestamp</var>.
-          </li>
-          <li>Update <var>presentation timestamp</var> and <var>decode timestamp</var> to the nearest audio sample timestamp based on sample rate of the audio in <var>overlapped frame</var>. If a timestamp is equidistant from both audio sample timestamps, then use the higher timestamp (e.g.,
-            <code>floor(x * sample_rate + 0.5) / sample_rate</code>).
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note66"><span>Note</span></div>
-              <div class="">
+        <section id="sourcebuffer-audio-splice-frame-algorithm">
+          <h4 id="x3-5-11-audio-splice-frame-algorithm"><span class="secno">3.5.11 </span>Audio Splice Frame Algorithm</h4>
+          <p>Follow these steps when the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> needs to generate a splice frame for two overlapping audio
+            <a href="#coded-frame">coded frames</a>:</p>
+          <ol>
+            <li>Let <var>track buffer</var> be the <a href="#track-buffer">track buffer</a> that will contain the splice.</li>
+            <li>Let <var>new coded frame</var> be the new <a href="#coded-frame">coded frame</a>, that is being added to <var>track buffer</var>, which triggered the need for a splice.</li>
+            <li>Let <var>presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> for <var>new coded frame</var></li>
+            <li>Let <var>decode timestamp</var> be the decode timestamp for <var>new coded frame</var>.</li>
+            <li>Let <var>frame duration</var> be the <a href="#coded-frame-duration">coded frame duration</a> of <var>new coded frame</var>.</li>
+            <li>Let <var>overlapped frame</var> be the <a href="#coded-frame">coded frame</a> in <var>track buffer</var> with a <a href="#presentation-interval">presentation interval</a> that contains <var>presentation timestamp</var>.
+            </li>
+            <li>Update <var>presentation timestamp</var> and <var>decode timestamp</var> to the nearest audio sample timestamp based on sample rate of the
+              audio in <var>overlapped frame</var>. If a timestamp is equidistant from both audio sample timestamps, then use the higher timestamp (e.g.,
+              <code>floor(x * sample_rate + 0.5) / sample_rate</code>).
+              <div class="note" id="issue-container-generatedID-65"><div role="heading" class="note-title marker" id="h-note-65" aria-level="5"><span>Note</span></div><div class="">
                 <p>For example, given the following values:</p>
                 <ul>
                   <li>The <a href="#presentation-timestamp">presentation timestamp</a> of <var>overlapped frame</var> equals 10.</li>
@@ -3297,655 +2917,500 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <li><var>presentation timestamp</var> equals 10.01255</li>
                   <li><var>decode timestamp</var> equals 10.01255</li>
                 </ul>
-                <p><var>presentation timestamp</var> and <var>decode timestamp</var> are updated to 10.0125 since 10.01255 is closer to 10 + 100/8000 (10.0125) than 10 + 101/8000 (10.012625)</p>
-              </div>
-            </div>
-          </li>
-          <li>If the user agent does not support crossfading then run the following steps:
-            <ol>
-              <li>Remove <var>overlapped frame</var> from <var>track buffer</var>.</li>
-              <li>Add a silence frame to <var>track buffer</var> with the following properties:
-                <ul>
-                  <li>The <a href="#presentation-timestamp">presentation timestamp</a> set to the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
-                  <li>The <a href="#decode-timestamp">decode timestamp</a> set to the <var>overlapped frame</var> <a href="#decode-timestamp">decode timestamp</a>.</li>
-                  <li>The <a href="#coded-frame-duration">coded frame duration</a> set to difference between <var>presentation timestamp</var> and the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
-                </ul>
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note67"><span>Note</span></div>
-                  <p class="">
-                    Some implementations <em class="rfc2119" title="MAY">MAY</em> apply fades to/from silence to coded frames on either side of the inserted silence to make the transition less jarring.
-                  </p>
-                </div>
-              </li>
-              <li>Return to caller without providing a splice frame.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note68"><span>Note</span></div>
-                  <p class="">
+                <p><var>presentation timestamp</var> and <var>decode timestamp</var> are updated to 10.0125 since 10.01255 is closer to
+                10 + 100/8000 (10.0125) than 10 + 101/8000 (10.012625)</p>
+              </div></div>
+            </li>
+            <li>If the user agent does not support crossfading then run the following steps:
+              <ol>
+                <li>Remove <var>overlapped frame</var> from <var>track buffer</var>.</li>
+                <li>Add a silence frame to <var>track buffer</var> with the following properties:
+                  <ul>
+                    <li>The <a href="#presentation-timestamp">presentation timestamp</a> set to the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
+                    <li>The <a href="#decode-timestamp">decode timestamp</a> set to the <var>overlapped frame</var> <a href="#decode-timestamp">decode timestamp</a>.</li>
+                    <li>The <a href="#coded-frame-duration">coded frame duration</a> set to difference between <var>presentation timestamp</var> and the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
+                  </ul>
+                  <div class="note" id="issue-container-generatedID-66"><div role="heading" class="note-title marker" id="h-note-66" aria-level="5"><span>Note</span></div><p class="">
+                    Some implementations <em class="rfc2119" title="MAY">MAY</em> apply fades to/from silence to coded frames on either side of the inserted silence to make the transition less
+                    jarring.
+                  </p></div>
+                </li>
+                <li>Return to caller without providing a splice frame.
+                  <div class="note" id="issue-container-generatedID-67"><div role="heading" class="note-title marker" id="h-note-67" aria-level="5"><span>Note</span></div><p class="">
                     This is intended to allow <var>new coded frame</var> to be added to the <var>track buffer</var> as if
                     <var>overlapped frame</var> had not been in the <var>track buffer</var> to begin with.
-                  </p>
-                </div>
-              </li>
-            </ol>
-          </li>
-          <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
-          <li>Let <var>splice end timestamp</var> equal the sum of <var>presentation timestamp</var> and the splice duration of 5 milliseconds.</li>
-          <li>Let <var>fade out coded frames</var> equal <var>overlapped frame</var> as well as any additional frames in <var>track buffer</var> that have a <a href="#presentation-timestamp">presentation timestamp</a> greater than <var>presentation timestamp</var> and less than <var>splice end timestamp</var>.</li>
-          <li>Remove all the frames included in <var>fade out coded frames</var> from <var>track buffer</var>.
-          </li>
-          <li>Return a splice frame with the following properties:
-            <ul>
-              <li>The <a href="#presentation-timestamp">presentation timestamp</a> set to the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
-              <li>The <a href="#decode-timestamp">decode timestamp</a> set to the <var>overlapped frame</var> <a href="#decode-timestamp">decode timestamp</a>.</li>
-              <li>The <a href="#coded-frame-duration">coded frame duration</a> set to difference between <var>frame end timestamp</var> and the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
-              <li>The fade out coded frames equals <var>fade-out coded frames</var>.</li>
-              <li>The fade in coded frame equal <var>new coded frame</var>.
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note69"><span>Note</span></div>
-                  <p class="">If the <var>new coded frame</var> is less than 5 milliseconds in duration, then coded frames that are appended after the
-                    <var>new coded frame</var> will be needed to properly render the splice.</p>
-                </div>
-              </li>
-              <li>The splice timestamp equals <var>presentation timestamp</var>.</li>
-            </ul>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note70"><span>Note</span></div>
-              <p class="">See the <a href="#sourcebuffer-audio-splice-rendering-algorithm">audio splice rendering algorithm</a> for details on how this splice frame is rendered.</p>
-            </div>
-          </li>
-        </ol>
-      </section>
-
-      <section id="sourcebuffer-audio-splice-rendering-algorithm" typeof="bibo:Chapter" resource="#sourcebuffer-audio-splice-rendering-algorithm" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-audio-splice-rendering-algorithm" resource="#h-sourcebuffer-audio-splice-rendering-algorithm"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.12 </span>Audio Splice Rendering Algorithm</span>
-        </h4>
-        <p>The following steps are run when a spliced frame, generated by the <a href="#sourcebuffer-audio-splice-frame-algorithm">audio splice frame algorithm</a>, needs to be rendered by the media element:</p>
-        <ol>
-          <li>Let <var>fade out coded frames</var> be the <a href="#coded-frame">coded frames</a> that are faded out during the splice.</li>
-          <li>Let <var>fade in coded frames</var> be the <a href="#coded-frame">coded frames</a> that are faded in during the splice.</li>
-          <li>Let <var>presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> of the first coded frame in <var>fade out coded frames</var>.</li>
-          <li>Let <var>end timestamp</var> be the sum of the <a href="#presentation-timestamp">presentation timestamp</a> and the <a href="#coded-frame-duration">coded frame duration</a> of the last frame in <var>fade in coded frames</var>.</li>
-          <li>Let <var>splice timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> where the splice starts. This corresponds with the <a href="#presentation-timestamp">presentation timestamp</a> of the first frame in
-            <var>fade in coded frames</var>.</li>
-          <li>Let <var>splice end timestamp</var> equal <var>splice timestamp</var> plus five milliseconds.</li>
-          <li>Let <var>fade out samples</var> be the samples generated by decoding <var>fade out coded frames</var>.</li>
-          <li>Trim <var>fade out samples</var> so that it only contains samples between <var>presentation timestamp</var> and <var>splice end timestamp</var>.</li>
-          <li>Let <var>fade in samples</var> be the samples generated by decoding <var>fade in coded frames</var>.</li>
-          <li>If <var>fade out samples</var> and <var>fade in samples</var> do not have a common sample rate and channel layout, then convert
-            <var>fade out samples</var> and <var>fade in samples</var> to a common sample rate and channel layout.</li>
-          <li>Let <var>output samples</var> be a buffer to hold the output samples.</li>
-          <li>Apply a linear gain fade out with a starting gain of 1 and an ending gain of 0 to the samples between
-            <var>splice timestamp</var> and <var>splice end timestamp</var> in <var>fade out samples</var>.</li>
-          <li>Apply a linear gain fade in with a starting gain of 0 and an ending gain of 1 to the samples between <var>splice timestamp</var> and
-            <var>splice end timestamp</var> in <var>fade in samples</var>.</li>
-          <li>Copy samples between <var>presentation timestamp</var> to <var>splice timestamp</var> from <var>fade out samples</var> into <var>output samples</var>.</li>
-          <li>For each sample between <var>splice timestamp</var> and <var>splice end timestamp</var>, compute the sum of a sample from <var>fade out samples</var> and the corresponding sample in <var>fade in samples</var> and store the result in <var>output samples</var>.</li>
-          <li>Copy samples between <var>splice end timestamp</var> to <var>end timestamp</var> from <var>fade in samples</var> into <var>output samples</var>.</li>
-          <li>Render <var>output samples</var>.</li>
-        </ol>
-        <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note71"><span>Note</span></div>
-          <div class="">
-            <p>Here is a graphical representation of this algorithm.</p>
-            <img src="audio_splice.png" alt="Audio splice diagram">
-          </div>
-        </div>
-      </section>
-
-      <section id="sourcebuffer-text-splice-frame-algorithm" typeof="bibo:Chapter" resource="#sourcebuffer-text-splice-frame-algorithm" property="bibo:hasPart">
-        <h4 id="h-sourcebuffer-text-splice-frame-algorithm" resource="#h-sourcebuffer-text-splice-frame-algorithm"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.5.13 </span>Text Splice Frame Algorithm</span>
-        </h4>
-        <p>Follow these steps when the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> needs to generate a splice frame for two overlapping timed text
-          <a href="#coded-frame">coded frames</a>:</p>
-        <ol>
-          <li>Let <var>track buffer</var> be the <a href="#track-buffer">track buffer</a> that will contain the splice.</li>
-          <li>Let <var>new coded frame</var> be the new <a href="#coded-frame">coded frame</a>, that is being added to <var>track buffer</var>, which triggered the need for a splice.</li>
-          <li>Let <var>presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> for <var>new coded frame</var></li>
-          <li>Let <var>decode timestamp</var> be the decode timestamp for <var>new coded frame</var>.</li>
-          <li>Let <var>frame duration</var> be the <a href="#coded-frame-duration">coded frame duration</a> of <var>new coded frame</var>.</li>
-          <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
-          <li>Let <var>first overlapped frame</var> be the <a href="#coded-frame">coded frame</a> in <var>track buffer</var> with a <a href="#presentation-interval">presentation interval</a> that contains <var>presentation timestamp</var>.
-          </li>
-          <li>Let <var>overlapped presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> of the <var>first overlapped frame</var>.</li>
-          <li>Let <var>overlapped frames</var> equal <var>first overlapped frame</var> as well as any additional frames in <var>track buffer</var> that have a <a href="#presentation-timestamp">presentation timestamp</a> greater than <var>presentation timestamp</var> and less than <var>frame end timestamp</var>.</li>
-          <li>Remove all the frames included in <var>overlapped frames</var> from <var>track buffer</var>.
-          </li>
-          <li>Update the <a href="#coded-frame-duration">coded frame duration</a> of the <var>first overlapped frame</var> to <var>presentation timestamp</var> - <var>overlapped presentation timestamp</var>.</li>
-          <li>Add <var>first overlapped frame</var> to the <var>track buffer</var>.
-          </li>
-          <li>Return to caller without providing a splice frame.
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note72"><span>Note</span></div>
-              <p class="">This is intended to allow <var>new coded frame</var> to be added to the <var>track buffer</var> as if it hadn't overlapped any frames in <var>track buffer</var> to begin with.</p>
-            </div>
-          </li>
-        </ol>
-      </section>
-    </section>
-  </section>
-
-  <section id="sourcebufferlist" typeof="bibo:Chapter" resource="#sourcebufferlist" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-sourcebufferlist" resource="#h-sourcebufferlist"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>SourceBufferList Object</span>
-    </h2>
-    <p>SourceBufferList is a simple container object for <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects. It provides read-only array access and fires events when the list is modified.</p>
-    <pre class="def idl"><span class="idlInterface" id="idl-def-sourcebufferlist" data-idl="" data-title="SourceBufferList">interface <span class="idlInterfaceID">SourceBufferList</span> : <span class="idlSuperclass">EventTarget</span> {
-<span class="idlAttribute" id="idl-def-sourcebufferlist-length" data-idl="" data-title="length" data-dfn-for="sourcebufferlist">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></span> <span class="idlAttrName"><a data-lt="length" href="#dom-sourcebufferlist-length" class="internalDFN" data-link-type="dfn" data-for="SourceBufferList"><code>length</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebufferlist-onaddsourcebuffer" data-idl="" data-title="onaddsourcebuffer" data-dfn-for="sourcebufferlist">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>  <span class="idlAttrName"><a data-lt="onaddsourcebuffer" href="#dom-sourcebufferlist-onaddsourcebuffer" class="internalDFN" data-link-type="dfn" data-for="SourceBufferList"><code>onaddsourcebuffer</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-sourcebufferlist-onremovesourcebuffer" data-idl="" data-title="onremovesourcebuffer" data-dfn-for="sourcebufferlist">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>  <span class="idlAttrName"><a data-lt="onremovesourcebuffer" href="#dom-sourcebufferlist-onremovesourcebuffer" class="internalDFN" data-link-type="dfn" data-for="SourceBufferList"><code>onremovesourcebuffer</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-sourcebufferlist-(unsigned_long)" data-idl="" data-title="" data-dfn-for="sourcebufferlist">    getter <span class="idlMethType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span> <span class="idlMethName"></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></span> <span class="idlParamName">index</span></span>);</span>
-};</span></pre>
-
-    <section id="attributes-2" typeof="bibo:Chapter" resource="#attributes-2" property="bibo:hasPart">
-      <h3 id="h-attributes-2" resource="#h-attributes-2"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Attributes</span>
-      </h3>
-      <dl class="attributes" data-dfn-for="SourceBufferList" data-link-for="SourceBufferList">
-        <dt><dfn data-dfn-for="sourcebufferlist" data-dfn-type="dfn" id="dom-sourcebufferlist-length" data-idl=""><code>length</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></span>, readonly       </dt>
-        <dd>
-          <p>Indicates the number of <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in the list.</p>
-        </dd>
-        <dt><dfn data-dfn-for="sourcebufferlist" data-dfn-type="dfn" id="dom-sourcebufferlist-onaddsourcebuffer" data-idl=""><code>onaddsourcebuffer</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
-          <p>The event handler for the <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> event.</p>
-        </dd>
-        <dt><dfn data-dfn-for="sourcebufferlist" data-dfn-type="dfn" id="dom-sourcebufferlist-onremovesourcebuffer" data-idl=""><code>onremovesourcebuffer</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
-        <dd>
-          <p>The event handler for the <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> event.</p>
-        </dd>
-      </dl>
-    </section>
-
-    <section id="methods-2" typeof="bibo:Chapter" resource="#methods-2" property="bibo:hasPart">
-      <h3 id="h-methods-2" resource="#h-methods-2"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Methods</span>
-      </h3>
-      <dl class="methods" data-dfn-for="SourceBufferList" data-link-for="SourceBufferList">
-        <dt><dfn data-lt-nodefault="" data-dfn-type="dfn" id="dfn-sourcebufferlist-getter"><code>getter</code></dfn></dt>
-        <dd>
-          <p>Allows the SourceBuffer objects in the list to be accessed with an array operator (i.e., []).</p>
-
-
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">index</td>
-                <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code><code>SourceBuffer</code></code></a></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
-            <li>If <var>index</var> is greater than or equal to the <code><a href="#dom-sourcebufferlist-length">length</a></code> attribute then return undefined and abort these steps.</li>
-            <li>Return the <var>index</var>'th <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in the list.</li>
+                  </p></div>
+                </li>
+              </ol>
+            </li>
+            <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
+            <li>Let <var>splice end timestamp</var> equal the sum of <var>presentation timestamp</var> and the splice duration of 5 milliseconds.</li>
+            <li>Let <var>fade out coded frames</var> equal <var>overlapped frame</var> as well as any additional frames in <var>track buffer</var> that
+              have a <a href="#presentation-timestamp">presentation timestamp</a> greater than <var>presentation timestamp</var> and less than <var>splice end timestamp</var>.</li>
+            <li>Remove all the frames included in <var>fade out coded frames</var> from <var>track buffer</var>.
+            </li><li>Return a splice frame with the following properties:
+              <ul>
+                <li>The <a href="#presentation-timestamp">presentation timestamp</a> set to the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
+                <li>The <a href="#decode-timestamp">decode timestamp</a> set to the <var>overlapped frame</var> <a href="#decode-timestamp">decode timestamp</a>.</li>
+                <li>The <a href="#coded-frame-duration">coded frame duration</a> set to difference between <var>frame end timestamp</var> and the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
+                <li>The fade out coded frames equals <var>fade-out coded frames</var>.</li>
+                <li>The fade in coded frame equal <var>new coded frame</var>.
+                  <div class="note" id="issue-container-generatedID-68"><div role="heading" class="note-title marker" id="h-note-68" aria-level="5"><span>Note</span></div><p class="">If the <var>new coded frame</var> is less than 5 milliseconds in duration, then coded frames that are appended after the
+                    <var>new coded frame</var> will be needed to properly render the splice.</p></div>
+                </li>
+                <li>The splice timestamp equals <var>presentation timestamp</var>.</li>
+              </ul>
+              <div class="note" id="issue-container-generatedID-69"><div role="heading" class="note-title marker" id="h-note-69" aria-level="5"><span>Note</span></div><p class="">See the <a href="#sourcebuffer-audio-splice-rendering-algorithm">audio splice rendering algorithm</a> for details on how this splice frame is rendered.</p></div>
+            </li>
           </ol>
-        </dd>
-      </dl>
+        </section>
+        <section id="sourcebuffer-audio-splice-rendering-algorithm">
+          <h4 id="x3-5-12-audio-splice-rendering-algorithm"><span class="secno">3.5.12 </span>Audio Splice Rendering Algorithm</h4>
+          <p>The following steps are run when a spliced frame, generated by the <a href="#sourcebuffer-audio-splice-frame-algorithm">audio splice frame algorithm</a>, needs to be rendered by the
+            media element:</p>
+          <ol>
+            <li>Let <var>fade out coded frames</var> be the <a href="#coded-frame">coded frames</a> that are faded out during the splice.</li>
+            <li>Let <var>fade in coded frames</var> be the <a href="#coded-frame">coded frames</a> that are faded in during the splice.</li>
+            <li>Let <var>presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> of the first coded frame in <var>fade out coded frames</var>.</li>
+            <li>Let <var>end timestamp</var> be the sum of the <a href="#presentation-timestamp">presentation timestamp</a> and the <a href="#coded-frame-duration">coded frame duration</a> of the last frame in <var>fade in coded frames</var>.</li>
+            <li>Let <var>splice timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> where the splice starts. This corresponds with the <a href="#presentation-timestamp">presentation timestamp</a> of the first frame in
+              <var>fade in coded frames</var>.</li>
+            <li>Let <var>splice end timestamp</var> equal <var>splice timestamp</var> plus five milliseconds.</li>
+            <li>Let <var>fade out samples</var> be the samples generated by decoding <var>fade out coded frames</var>.</li>
+            <li>Trim <var>fade out samples</var> so that it only contains samples between <var>presentation timestamp</var> and <var>splice end timestamp</var>.</li>
+            <li>Let <var>fade in samples</var> be the samples generated by decoding <var>fade in coded frames</var>.</li>
+            <li>If <var>fade out samples</var> and <var>fade in samples</var> do not have a common sample rate and channel layout, then convert
+              <var>fade out samples</var> and <var>fade in samples</var> to a common sample rate and channel layout.</li>
+            <li>Let <var>output samples</var> be a buffer to hold the output samples.</li>
+            <li>Apply a linear gain fade out with a starting gain of 1 and an ending gain of 0 to the samples between
+              <var>splice timestamp</var> and <var>splice end timestamp</var> in <var>fade out samples</var>.</li>
+            <li>Apply a linear gain fade in with a starting gain of 0 and an ending gain of 1 to the samples between <var>splice timestamp</var> and
+              <var>splice end timestamp</var> in <var>fade in samples</var>.</li>
+            <li>Copy samples between <var>presentation timestamp</var> to <var>splice timestamp</var> from <var>fade out samples</var> into <var>output samples</var>.</li>
+            <li>For each sample between <var>splice timestamp</var> and <var>splice end timestamp</var>, compute the sum of a sample from <var>fade out samples</var> and the
+              corresponding sample in <var>fade in samples</var> and store the result in <var>output samples</var>.</li>
+            <li>Copy samples between <var>splice end timestamp</var> to <var>end timestamp</var> from <var>fade in samples</var> into <var>output samples</var>.</li>
+            <li>Render <var>output samples</var>.</li>
+          </ol>
+          <div class="note" id="issue-container-generatedID-70"><div role="heading" class="note-title marker" id="h-note-70" aria-level="5"><span>Note</span></div><div class="">
+            <p>Here is a graphical representation of this algorithm.</p>
+            <img src="audio_splice.png" alt="Audio splice diagram" height="0" width="0">
+          </div></div>
+        </section>
+        <section id="sourcebuffer-text-splice-frame-algorithm">
+          <h4 id="x3-5-13-text-splice-frame-algorithm"><span class="secno">3.5.13 </span>Text Splice Frame Algorithm</h4>
+          <p>Follow these steps when the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> needs to generate a splice frame for two overlapping timed text
+            <a href="#coded-frame">coded frames</a>:</p>
+          <ol>
+            <li>Let <var>track buffer</var> be the <a href="#track-buffer">track buffer</a> that will contain the splice.</li>
+            <li>Let <var>new coded frame</var> be the new <a href="#coded-frame">coded frame</a>, that is being added to <var>track buffer</var>, which triggered the need for a splice.</li>
+            <li>Let <var>presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> for <var>new coded frame</var></li>
+            <li>Let <var>decode timestamp</var> be the decode timestamp for <var>new coded frame</var>.</li>
+            <li>Let <var>frame duration</var> be the <a href="#coded-frame-duration">coded frame duration</a> of <var>new coded frame</var>.</li>
+            <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
+            <li>Let <var>first overlapped frame</var> be the <a href="#coded-frame">coded frame</a> in <var>track buffer</var> with a <a href="#presentation-interval">presentation interval</a> that contains <var>presentation timestamp</var>.
+            </li>
+            <li>Let <var>overlapped presentation timestamp</var> be the <a href="#presentation-timestamp">presentation timestamp</a> of the <var>first overlapped frame</var>.</li>
+            <li>Let <var>overlapped frames</var> equal <var>first overlapped frame</var> as well as any additional frames in <var>track buffer</var> that
+              have a <a href="#presentation-timestamp">presentation timestamp</a> greater than <var>presentation timestamp</var> and less than <var>frame end timestamp</var>.</li>
+            <li>Remove all the frames included in <var>overlapped frames</var> from <var>track buffer</var>.
+            </li><li>Update the <a href="#coded-frame-duration">coded frame duration</a> of the <var>first overlapped frame</var> to <var>presentation timestamp</var> - <var>overlapped presentation timestamp</var>.</li>
+            <li>Add <var>first overlapped frame</var> to the <var>track buffer</var>.
+            </li><li>Return to caller without providing a splice frame.
+              <div class="note" id="issue-container-generatedID-71"><div role="heading" class="note-title marker" id="h-note-71" aria-level="5"><span>Note</span></div><p class="">This is intended to allow <var>new coded frame</var> to be added to the <var>track buffer</var> as if
+                it hadn't overlapped any frames in <var>track buffer</var> to begin with.</p></div>
+            </li>
+          </ol>
+        </section>
+      </section>
     </section>
 
-    <section id="sourcebufferlist-events" typeof="bibo:Chapter" resource="#sourcebufferlist-events" property="bibo:hasPart">
-      <h3 id="h-sourcebufferlist-events" resource="#h-sourcebufferlist-events"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3 </span>Event Summary</span>
-      </h3>
-      <table class="old-table">
-        <thead>
-          <tr>
-            <th>Event name</th>
-            <th>Interface</th>
-            <th>Dispatched when...</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><dfn id="dom-evt-addsourcebuffer"><code>addsourcebuffer</code></dfn></td>
-            <td><code>Event</code></td>
-            <td>When a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> is added to the list.</td>
-          </tr>
-          <tr>
-            <td><dfn id="dom-evt-removesourcebuffer"><code>removesourcebuffer</code></dfn></td>
-            <td><code>Event</code></td>
-            <td>When a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> is removed from the list.</td>
-          </tr>
-        </tbody>
-      </table>
+    <section id="sourcebufferlist">
+      <!--OddPage--><h2 id="x4-sourcebufferlist-object"><span class="secno">4. </span>SourceBufferList Object</h2>
+      <p>SourceBufferList is a simple container object for <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects. It provides read-only array access and fires events when the list is modified.</p>
+<div><pre class="def idl"><span class="idlInterface" id="idl-def-sourcebufferlist" data-idl="" data-title="SourceBufferList">interface <span class="idlInterfaceID">SourceBufferList</span> : <span class="idlSuperclass">EventTarget</span> {
+<span class="idlAttribute" id="idl-def-sourcebufferlist-length" data-idl="" data-title="length" data-dfn-for="sourcebufferlist">    readonly attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></span> <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebufferlist" data-lt="" href="#dom-sourcebufferlist-length" class="internalDFN" data-link-type="dfn"><code>length</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebufferlist-onaddsourcebuffer" data-idl="" data-title="onaddsourcebuffer" data-dfn-for="sourcebufferlist">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>  <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebufferlist" data-lt="" href="#dom-sourcebufferlist-onaddsourcebuffer" class="internalDFN" data-link-type="dfn"><code>onaddsourcebuffer</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-sourcebufferlist-onremovesourcebuffer" data-idl="" data-title="onremovesourcebuffer" data-dfn-for="sourcebufferlist">             attribute <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span>  <span class="idlAttrName"><a data-no-default="" data-link-for="sourcebufferlist" data-lt="" href="#dom-sourcebufferlist-onremovesourcebuffer" class="internalDFN" data-link-type="dfn"><code>onremovesourcebuffer</code></a></span>;</span>
+<span class="idlMethod" id="idl-def-sourcebufferlist--index" data-idl="" data-title="" data-dfn-for="sourcebufferlist">    getter <span class="idlMethType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span> <span class="idlMethName"></span>(<span class="idlParam"><span class="idlParamType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></span> <span class="idlParamName">index</span></span>);</span>
+};</span></pre></div>
+      <section id="attributes-1">
+        <h3 id="x4-1-attributes"><span class="secno">4.1 </span>Attributes</h3>
+        <dl class="attributes" data-dfn-for="SourceBufferList" data-link-for="SourceBufferList">
+          <dt><dfn data-dfn-for="sourcebufferlist" data-dfn-type="dfn" id="dom-sourcebufferlist-length" data-idl="" data-title="length"><code>length</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></span>, readonly       </dt>
+          <dd>
+            <p>Indicates the number of <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects in the list.</p>
+          </dd>
+          <dt><dfn data-dfn-for="sourcebufferlist" data-dfn-type="dfn" id="dom-sourcebufferlist-onaddsourcebuffer" data-idl="" data-title="onaddsourcebuffer"><code>onaddsourcebuffer</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
+          <dd>
+            <p>The event handler for the <code><a href="#dom-evt-addsourcebuffer">addsourcebuffer</a></code> event.</p>
+          </dd>
+          <dt><dfn data-dfn-for="sourcebufferlist" data-dfn-type="dfn" id="dom-sourcebufferlist-onremovesourcebuffer" data-idl="" data-title="onremovesourcebuffer"><code>onremovesourcebuffer</code></dfn> of type <span class="idlAttrType"><code><a href="https://www.w3.org/TR/html51/webappapis.html#typedefdef-eventhandlernonnull-eventhandler">EventHandler</a></code></span></dt>
+          <dd>
+            <p>The event handler for the <code><a href="#dom-evt-removesourcebuffer">removesourcebuffer</a></code> event.</p>
+          </dd>
+        </dl>
+      </section>
+      <section id="methods-1">
+        <h3 id="x4-2-methods"><span class="secno">4.2 </span>Methods</h3>
+        <dl class="methods" data-dfn-for="SourceBufferList" data-link-for="SourceBufferList">
+          <dt><dfn data-lt-nodefault="" data-lt="sourcebufferlist-getter" data-dfn-type="dfn" id="dfn-sourcebufferlist-getter"><code>getter</code></dfn></dt>
+          <dd>
+            <p>Allows the SourceBuffer objects in the list to be accessed with an array operator (i.e., []).</p>
+
+            
+            <table class="parameters">
+              <tbody>
+                <tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr>
+                <tr>
+                  <td class="prmName">index</td>
+                  <td class="prmType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></code></td>
+                  <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
+                  <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
+                  <td class="prmDesc"></td>
+                </tr>
+              </tbody>
+            </table>
+            <div><em>Return type: </em><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code><code>SourceBuffer</code></code></a></div>
+          <p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
+              <li>If <var>index</var> is greater than or equal to the <code><a href="#dom-sourcebufferlist-length">length</a></code> attribute then return undefined and abort these steps.</li>
+              <li>Return the <var>index</var>'th <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in the list.</li>
+            </ol></dd>
+        </dl>
+      </section>
+
+      <section id="sourcebufferlist-events">
+        <h3 id="x4-3-event-summary"><span class="secno">4.3 </span>Event Summary</h3>
+        <table class="old-table">
+          <thead>
+            <tr>
+              <th>Event name</th>
+              <th>Interface</th>
+              <th>Dispatched when...</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><dfn id="dom-evt-addsourcebuffer"><code>addsourcebuffer</code></dfn></td>
+              <td><code>Event</code></td>
+              <td>When a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> is added to the list.</td>
+            </tr>
+            <tr>
+              <td><dfn id="dom-evt-removesourcebuffer"><code>removesourcebuffer</code></dfn></td>
+              <td><code>Event</code></td>
+              <td>When a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> is removed from the list.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </section>
-  </section>
 
-  <section id="url" typeof="bibo:Chapter" resource="#url" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-url" resource="#h-url"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>URL Object Extensions</span>
-    </h2>
-    <p>This section specifies extensions to the <a href="https://www.w3.org/TR/FileAPI/#URL-object">URL</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] object definition.</p>
+    <section id="url">
+      <!--OddPage--><h2 id="x5-url-object-extensions"><span class="secno">5. </span>URL Object Extensions</h2>
+      <p>This section specifies extensions to the <a href="https://www.w3.org/TR/FileAPI/#URL-object">URL</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] object definition.</p>
 
-    <pre class="def idl"><span class="idlInterface" id="idl-def-url-partial-1" data-idl="" data-title="URL">[<span class="extAttr"><span class="extAttrName">Exposed</span>=<span class="extAttrRhs">Window</span></span>]
+<div><pre class="def idl"><span class="idlInterface" id="idl-def-url-partial-1" data-idl="" data-title="URL">[<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a></span>=<span class="extAttrRhs">Window</span></span>]
 partial interface <span class="idlInterfaceID">URL</span> {
-<span class="idlMethod" id="idl-def-url-createobjecturl(mediasource)" data-idl="" data-title="createObjectURL" data-dfn-for="url">    static <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlMethName"><a data-lt="createObjectURL" href="#dom-url-createobjecturl" class="internalDFN" data-link-type="dfn" data-for="URL"><code>createObjectURL</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a></span> <span class="idlParamName">mediaSource</span></span>);</span>
-};</span></pre>
-
-    <section id="methods-3" typeof="bibo:Chapter" resource="#methods-3" property="bibo:hasPart">
-      <h3 id="h-methods-3" resource="#h-methods-3"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Methods</span>
-      </h3>
-      <dl class="methods" data-dfn-for="URL" data-link-for="URL"><dt><dfn data-dfn-for="url" data-dfn-type="dfn" id="dom-url-createobjecturl" data-idl=""><code>createObjectURL</code></dfn>, static</dt>
-        <dd>
+<span class="idlMethod" id="idl-def-url-createobjecturl-mediasource" data-idl="" data-title="createObjectURL" data-dfn-for="url">    static <span class="idlMethType"><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></code></span> <span class="idlMethName"><a data-no-default="" data-link-for="url" data-lt="createObjectURL|createobjecturl()" href="#dom-url-createobjecturl" class="internalDFN" data-link-type="dfn"><code>createObjectURL</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a></span> <span class="idlParamName">mediaSource</span></span>);</span>
+};</span></pre></div><section id="methods-2"><h3 id="x5-1-methods"><span class="secno">5.1 </span>Methods</h3><dl class="methods" data-dfn-for="URL" data-link-for="URL"><dt><dfn data-dfn-for="url" data-dfn-type="dfn" id="dom-url-createobjecturl" data-idl="" data-title="createObjectURL" data-lt="createObjectURL|createobjecturl()"><code>createObjectURL</code></dfn>, static</dt><dd>
           <p>Creates URLs for <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> objects.</p>
 
-
-          <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note73"><span>Note</span></div>
-            <p class="">This algorithm is intended to mirror the behavior of the <a href="https://www.w3.org/TR/FileAPI/#dfn-createObjectURL">createObjectURL()</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] method, which does not auto-revoke the created URL. Web authors are encouraged to use <a href="https://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL">revokeObjectURL()</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] for any <a href="#mediasource-object-url">MediaSource object URL</a> that is no longer needed for attachment to a media element.</p>
-          </div>
-          <table class="parameters">
-            <tbody>
-              <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Nullable</th>
-                <th>Optional</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td class="prmName">mediaSource</td>
-                <td class="prmType"><code>MediaSource</code></td>
-                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
-                <td class="prmDesc"></td>
-              </tr>
-            </tbody>
-          </table>
-          <div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString" class="idlType">DOMString</a></code></div>
-          <p>When this method is invoked, the user agent must run the following steps:</p>
-          <ol class="method-algorithm">
+          
+          <div class="note" id="issue-container-generatedID-72"><div role="heading" class="note-title marker" id="h-note-72" aria-level="4"><span>Note</span></div><p class="">This algorithm is intended to mirror the behavior of the <a href="https://www.w3.org/TR/FileAPI/#dfn-createObjectURL">createObjectURL()</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] method, which does not auto-revoke the created URL. Web authors are encouraged to use <a href="https://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL">revokeObjectURL()</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] for any <a href="#mediasource-object-url">MediaSource object URL</a> that is no longer needed for attachment to a media element.</p></div>
+        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">mediaSource</td><td class="prmType"><code>MediaSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString" class="idlType">DOMString</a></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>Return a unique <a href="#mediasource-object-url">MediaSource object URL</a> that can be used to dereference the <var>mediaSource</var> argument.</li>
-          </ol>
-        </dd>
-      </dl>
+          </ol></dd></dl></section>
     </section>
-  </section>
 
-  <section id="htmlmediaelement-extensions" typeof="bibo:Chapter" resource="#htmlmediaelement-extensions" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-htmlmediaelement-extensions" resource="#h-htmlmediaelement-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>HTMLMediaElement Extensions</span>
-    </h2>
-    <p>This section specifies what existing attributes on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> <em class="rfc2119" title="MUST">MUST</em> return when a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> is attached to the element.</p>
+    <section id="htmlmediaelement-extensions">
+      <!--OddPage--><h2 id="x6-htmlmediaelement-extensions"><span class="secno">6. </span>HTMLMediaElement Extensions</h2>
+      <p>This section specifies what existing attributes on the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> <em class="rfc2119" title="MUST">MUST</em> return when a <a href="#idl-def-mediasource" class="internalDFN" data-link-type="dfn"><code>MediaSource</code></a> is attached to the element.</p>
 
-    <p>The <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-seekable">HTMLMediaElement.seekable</a></code> attribute returns a new static <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a> created based on the following steps:</p>
-    <dl class="switch">
-      <dt>If <code><a href="#dom-mediasource-duration">duration</a></code> equals NaN:</dt>
-      <dd>Return an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object.</dd>
-      <dt>If <code><a href="#dom-mediasource-duration">duration</a></code> equals positive Infinity:</dt>
-      <dd>
-        <ol>
-          <li>If <var><a href="#live-seekable-range">live seekable range</a></var> is not empty:
-            <ol>
-              <li>Let <var>union ranges</var> be the union of <var><a href="#live-seekable-range">live seekable range</a></var> and the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute.</li>
-              <li>Return a single range with a start time equal to the earliest start time in <var>union ranges</var> and an end time equal to the highest end time in <var>union ranges</var> and abort these steps.</li>
-            </ol>
-          </li>
-          <li>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute returns an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object, then return an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object and abort these steps.</li>
-          <li>Return a single range with a start time of 0 and an end time equal to the highest end time reported by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute.
-          </li>
-        </ol>
-      </dd>
-      <dt>Otherwise:</dt>
-      <dd>Return a single range with a start time of 0 and an end time equal to <code><a href="#dom-mediasource-duration">duration</a></code>.</dd>
-    </dl>
+      <p>The <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-seekable">HTMLMediaElement.seekable</a></code> attribute returns a new static <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a> created based on the following steps:</p>
+      <dl class="switch">
+        <dt>If <code><a href="#dom-mediasource-duration">duration</a></code> equals NaN:</dt>
+        <dd>Return an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object.</dd>
+        <dt>If <code><a href="#dom-mediasource-duration">duration</a></code> equals positive Infinity:</dt>
+        <dd>
+          <ol>
+            <li>If <var><a href="#live-seekable-range">live seekable range</a></var> is not empty:
+              <ol>
+                <li>Let <var>union ranges</var> be the union of <var><a href="#live-seekable-range">live seekable range</a></var> and the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute.</li>
+                <li>Return a single range with a start time equal to the earliest start time in <var>union ranges</var> and an end time equal to the highest end time in <var>union ranges</var> and abort these steps.</li>
+              </ol>
+            </li>
+            <li>If the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute returns an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code>
+              object, then return an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object and abort these steps.</li>
+            <li>Return a single range with a start time of 0 and an end time equal to the highest end time reported by the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute.
+        </li></ol></dd>
+        <dt>Otherwise:</dt>
+        <dd>Return a single range with a start time of 0 and an end time equal to <code><a href="#dom-mediasource-duration">duration</a></code>.</dd>
+      </dl>
 
-    <p id="dom-htmlmediaelement.buffered">The <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute returns a static <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a> based on the following steps.</p>
-    <ol>
-      <li>Let <var>intersection ranges</var> equal an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object.</li>
-      <li>If <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.length does not equal 0 then run the following steps:
-        <ol>
-          <li>Let <var>active ranges</var> be the ranges returned by <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> for each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
-          <li>Let <var>highest end time</var> be the largest range end time in the <var>active ranges</var>.</li>
-          <li>Let <var>intersection ranges</var> equal a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> object containing a single range from 0 to <var>highest end time</var>.</li>
-          <li>For each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> run the following steps:
-            <ol>
-              <li>Let <var>source ranges</var> equal the ranges returned by the <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> attribute on the current <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</li>
-              <li>If <code><a href="#dom-readystate">readyState</a></code> is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>, then set the end time on the last range in <var>source ranges</var> to
-                <var>highest end time</var>.</li>
-              <li>Let <var>new intersection ranges</var> equal the intersection between the <var>intersection ranges</var> and the <var>source ranges</var>.</li>
-              <li>Replace the ranges in <var>intersection ranges</var> with the <var>new intersection ranges</var>.</li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>If the current value of this attribute has not been set by this algorithm or
-        <var>intersection ranges</var> does not contain the exact same range information as the current value of this attribute, then update the current value of this attribute to
-        <var>intersection ranges</var>.
-      </li>
-      <li>Return the current value of this attribute.</li>
-    </ol>
-  </section>
+      <p id="dom-htmlmediaelement.buffered">The <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-buffered">HTMLMediaElement.buffered</a></code> attribute returns a static <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a> based on the following steps.</p>
+      <ol>
+        <li>Let <var>intersection ranges</var> equal an empty <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRanges</a></code> object.</li>
+        <li>If <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.length does not equal 0 then run the following steps:
+          <ol>
+            <li>Let <var>active ranges</var> be the ranges returned by <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> for each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code>.</li>
+            <li>Let <var>highest end time</var> be the largest range end time in the <var>active ranges</var>.</li>
+            <li>Let <var>intersection ranges</var> equal a <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timeranges-timeranges">TimeRange</a></code> object containing a single range from 0 to <var>highest end time</var>.</li>
+            <li>For each <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> object in <code><a href="#dom-mediasource-activesourcebuffers">activeSourceBuffers</a></code> run the following steps:
+              <ol>
+                <li>Let <var>source ranges</var> equal the ranges returned by the <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> attribute on the current <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>.</li>
+                <li>If <code><a href="#dom-readystate">readyState</a></code> is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>, then set the end time on the last range in <var>source ranges</var> to
+                  <var>highest end time</var>.</li>
+                <li>Let <var>new intersection ranges</var> equal the intersection between the <var>intersection ranges</var> and the <var>source ranges</var>.</li>
+                <li>Replace the ranges in <var>intersection ranges</var> with the <var>new intersection ranges</var>.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>If the current value of this attribute has not been set by this algorithm or
+          <var>intersection ranges</var> does not contain the exact same range information as the
+          current value of this attribute, then update the current value of this attribute to
+          <var>intersection ranges</var>.
+        </li><li>Return the current value of this attribute.</li>
+      </ol>
+    </section>
 
-  <section id="audio-track-extensions" typeof="bibo:Chapter" resource="#audio-track-extensions" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-audio-track-extensions" resource="#h-audio-track-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>AudioTrack Extensions</span>
-    </h2>
-    <p>This section specifies extensions to the HTML <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> definition.</p>
+    <section id="audio-track-extensions">
+      <!--OddPage--><h2 id="x7-audiotrack-extensions"><span class="secno">7. </span>AudioTrack Extensions</h2>
+      <p>This section specifies extensions to the HTML <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code> definition.</p>
 
-    <div><pre class="def idl"><span class="idlInterface" id="idl-def-audiotrack-partial-1" data-idl="" data-title="AudioTrack">partial interface <span class="idlInterfaceID">AudioTrack</span> {
-<span class="idlAttribute" id="idl-def-audiotrack-sourcebuffer" data-idl="" data-title="sourceBuffer" data-dfn-for="audiotrack">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>?</span> <span class="idlAttrName"><a data-lt="sourceBuffer" href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn" data-for="AudioTrack"><code>sourceBuffer</code></a></span>;</span>
-};</span></pre>
+      <div><div><pre class="def idl"><span class="idlInterface" id="idl-def-audiotrack-partial-1" data-idl="" data-title="AudioTrack">partial interface <span class="idlInterfaceID">AudioTrack</span> {
+<span class="idlAttribute" id="idl-def-audiotrack-sourcebuffer" data-idl="" data-title="sourceBuffer" data-dfn-for="audiotrack">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>?</span> <span class="idlAttrName"><a data-no-default="" data-link-for="audiotrack" data-lt="" href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>sourceBuffer</code></a></span>;</span>
+};</span></pre></div><section><h3 id="attributes-2">Attributes</h3><dl class="attributes" data-dfn-for="AudioTrack" data-link-for="AudioTrack"><dt><dfn data-dfn-for="audiotrack" data-dfn-type="dfn" id="dom-audiotrack-sourcebuffer" data-idl="" data-title="sourceBuffer"><code>sourceBuffer</code></dfn> of type <span class="idlAttrType"><a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a></span>, readonly       , nullable</dt><dd>
+          <p>Returns the <a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> that created this track. Returns null if this track was not created by a <a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> or the <a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of its <a href="#parent-media-source">parent media source</a>.</p>
+        </dd></dl></section></div>
+    </section>
 
-      <section typeof="bibo:Chapter" resource="#attributes-3" property="bibo:hasPart">
-        <h3 id="attributes-3" resource="#attributes-3"><span property="xhv:role" resource="xhv:heading">Attributes</span></h3>
-        <dl class="attributes" data-dfn-for="AudioTrack" data-link-for="AudioTrack"><dt><dfn data-dfn-for="audiotrack" data-dfn-type="dfn" id="dom-audiotrack-sourcebuffer" data-idl=""><code>sourceBuffer</code></dfn> of type <span class="idlAttrType"><a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span>, readonly       , nullable</dt>
-          <dd>
-            <p>Returns the <a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> that created this track. Returns null if this track was not created by a <a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> or the <a href="#dom-audiotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of its <a href="#parent-media-source">parent media source</a>.</p>
-          </dd>
-        </dl>
-      </section>
-    </div>
-  </section>
+    <section id="video-track-extensions">
+      <!--OddPage--><h2 id="x8-videotrack-extensions"><span class="secno">8. </span>VideoTrack Extensions</h2>
+      <p>This section specifies extensions to the HTML <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> definition.</p>
 
-  <section id="video-track-extensions" typeof="bibo:Chapter" resource="#video-track-extensions" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-video-track-extensions" resource="#h-video-track-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">8. </span>VideoTrack Extensions</span>
-    </h2>
-    <p>This section specifies extensions to the HTML <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> definition.</p>
+      <div><div><pre class="def idl"><span class="idlInterface" id="idl-def-videotrack-partial-1" data-idl="" data-title="VideoTrack">partial interface <span class="idlInterfaceID">VideoTrack</span> {
+<span class="idlAttribute" id="idl-def-videotrack-sourcebuffer" data-idl="" data-title="sourceBuffer" data-dfn-for="videotrack">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>?</span> <span class="idlAttrName"><a data-no-default="" data-link-for="videotrack" data-lt="" href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>sourceBuffer</code></a></span>;</span>
+};</span></pre></div><section><h3 id="attributes-3">Attributes</h3><dl class="attributes" data-dfn-for="VideoTrack" data-link-for="VideoTrack"><dt><dfn data-dfn-for="videotrack" data-dfn-type="dfn" id="dom-videotrack-sourcebuffer" data-idl="" data-title="sourceBuffer"><code>sourceBuffer</code></dfn> of type <span class="idlAttrType"><a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a></span>, readonly       , nullable</dt><dd>
+          <p>Returns the <a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> that created this track. Returns null if this track was not created by a <a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> or the <a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of its <a href="#parent-media-source">parent media source</a>.</p>
+        </dd></dl></section></div>
+    </section>
 
-    <div><pre class="def idl"><span class="idlInterface" id="idl-def-videotrack-partial-1" data-idl="" data-title="VideoTrack">partial interface <span class="idlInterfaceID">VideoTrack</span> {
-<span class="idlAttribute" id="idl-def-videotrack-sourcebuffer" data-idl="" data-title="sourceBuffer" data-dfn-for="videotrack">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>?</span> <span class="idlAttrName"><a data-lt="sourceBuffer" href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn" data-for="VideoTrack"><code>sourceBuffer</code></a></span>;</span>
-};</span></pre>
+    <section id="text-track-extensions">
+      <!--OddPage--><h2 id="x9-texttrack-extensions"><span class="secno">9. </span>TextTrack Extensions</h2>
+      <p>This section specifies extensions to the HTML <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> definition.</p>
 
-      <section typeof="bibo:Chapter" resource="#attributes-4" property="bibo:hasPart">
-        <h3 id="attributes-4" resource="#attributes-4"><span property="xhv:role" resource="xhv:heading">Attributes</span></h3>
-        <dl class="attributes" data-dfn-for="VideoTrack" data-link-for="VideoTrack"><dt><dfn data-dfn-for="videotrack" data-dfn-type="dfn" id="dom-videotrack-sourcebuffer" data-idl=""><code>sourceBuffer</code></dfn> of type <span class="idlAttrType"><a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span>, readonly       , nullable</dt>
-          <dd>
-            <p>Returns the <a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> that created this track. Returns null if this track was not created by a <a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> or the <a href="#dom-videotrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of its <a href="#parent-media-source">parent media source</a>.</p>
-          </dd>
-        </dl>
-      </section>
-    </div>
-  </section>
+      <div><div><pre class="def idl"><span class="idlInterface" id="idl-def-texttrack-partial-1" data-idl="" data-title="TextTrack">partial interface <span class="idlInterfaceID">TextTrack</span> {
+<span class="idlAttribute" id="idl-def-texttrack-sourcebuffer" data-idl="" data-title="sourceBuffer" data-dfn-for="texttrack">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>?</span> <span class="idlAttrName"><a data-no-default="" data-link-for="texttrack" data-lt="" href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>sourceBuffer</code></a></span>;</span>
+};</span></pre></div><section><h3 id="attributes-4">Attributes</h3><dl class="attributes" data-dfn-for="TextTrack" data-link-for="TextTrack"><dt><dfn data-dfn-for="texttrack" data-dfn-type="dfn" id="dom-texttrack-sourcebuffer" data-idl="" data-title="sourceBuffer"><code>sourceBuffer</code></dfn> of type <span class="idlAttrType"><a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a></span>, readonly       , nullable</dt><dd>
+          <p>Returns the <a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> that created this track. Returns null if this track was not created by a <a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> or the <a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn">SourceBuffer</a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of its <a href="#parent-media-source">parent media source</a>.</p>
+        </dd></dl></section></div>
+    </section>
 
-  <section id="text-track-extensions" typeof="bibo:Chapter" resource="#text-track-extensions" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-text-track-extensions" resource="#h-text-track-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">9. </span>TextTrack Extensions</span>
-    </h2>
-    <p>This section specifies extensions to the HTML <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> definition.</p>
+    <section id="byte-stream-formats">
+      <!--OddPage--><h2 id="x10-byte-stream-formats"><span class="secno">10. </span>Byte Stream Formats</h2>
+      <p>The bytes provided through <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> for a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> form a logical byte stream. The format and
+        semantics of these byte streams are defined in <dfn id="byte-stream-format-specs" data-dfn-type="dfn">byte stream format specifications</dfn>.
+        The byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] provides mappings between a MIME type that may be passed to <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code>, 
+        <code><a href="#dom-mediasource-istypesupported">isTypeSupported()</a></code> or <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> and the byte stream format expected by a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> using that MIME type for parsing newly appended data. Implementations are encouraged to register
+        mappings for byte stream formats they support to facilitate interoperability. The byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] is the authoritative source for these
+        mappings. If an implementation claims to support a MIME type listed in the registry, its <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> implementation <em class="rfc2119" title="MUST">MUST</em> conform to the
+        <a href="#byte-stream-format-specs">byte stream format specification</a> listed in the registry entry.</p>
+      <div class="note" id="issue-container-generatedID-73"><div role="heading" class="note-title marker" id="h-note-73" aria-level="3"><span>Note</span></div><p class="">The byte stream format specifications in the registry are not intended to define new storage formats. They simply outline the subset of
+        existing storage format structures that implementations of this specification will accept.</p></div>
+      <div class="note" id="issue-container-generatedID-74"><div role="heading" class="note-title marker" id="h-note-74" aria-level="3"><span>Note</span></div><p class="">Byte stream format parsing and validation is implemented in the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</p></div>
 
-    <div><pre class="def idl"><span class="idlInterface" id="idl-def-texttrack-partial-1" data-idl="" data-title="TextTrack">partial interface <span class="idlInterfaceID">TextTrack</span> {
-<span class="idlAttribute" id="idl-def-texttrack-sourcebuffer" data-idl="" data-title="sourceBuffer" data-dfn-for="texttrack">    readonly attribute <span class="idlAttrType"><a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a>?</span> <span class="idlAttrName"><a data-lt="sourceBuffer" href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn" data-for="TextTrack"><code>sourceBuffer</code></a></span>;</span>
-};</span></pre>
+      <p>This section provides general requirements for all byte stream format specifications:</p>
+      <ul>
+        <li>A byte stream format specification <em class="rfc2119" title="MUST">MUST</em> define <a href="#init-segment">initialization segments</a> and <a href="#media-segment">media segments</a>.</li>
+        <li>A byte stream format <em class="rfc2119" title="SHOULD">SHOULD</em> provide references for sourcing <a href="#idl-def-audiotrack-partial-1" class="internalDFN" data-link-type="dfn"><code>AudioTrack</code></a>, <a href="#idl-def-videotrack-partial-1" class="internalDFN" data-link-type="dfn"><code>VideoTrack</code></a>, and <a href="#idl-def-texttrack-partial-1" class="internalDFN" data-link-type="dfn"><code>TextTrack</code></a> attribute values
+          from data in <a href="#init-segment">initialization segments</a>.
+          <div class="note" id="issue-container-generatedID-75"><div role="heading" class="note-title marker" id="h-note-75" aria-level="3"><span>Note</span></div><p class="">If the byte stream format covers a format similar to one covered in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>], then
+            it <em class="rfc2119" title="SHOULD">SHOULD</em> try to use the same attribute mappings so that Media Source Extensions playback and non-Media Source Extensions playback provide the
+            same track information.</p></div>
+        </li>
+        <li>It <em class="rfc2119" title="MUST">MUST</em> be possible to identify segment boundaries and segment type (initialization or media) by examining the byte stream alone.</li>
+        <li>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> when any of the following conditions are met:
+          <ol>
+            <li>
+              <p>The number and type of tracks are not consistent.</p>
+              <div class="note" id="issue-container-generatedID-76"><div role="heading" class="note-title marker" id="h-note-76" aria-level="3"><span>Note</span></div><p class="">For example, if the first <a href="#init-segment">initialization segment</a> has 2 audio tracks and 1 video track, then all <a href="#init-segment">initialization segments</a> that follow it in the byte stream <em class="rfc2119" title="MUST">MUST</em> describe 2 audio tracks and 1 video track.</p></div>
+            </li>
+            <li><a href="#track-id">Track IDs</a> are not the same across <a href="#init-segment">initialization segments</a>, for segments describing multiple tracks of a single type (e.g., 2 audio tracks).</li>
+            <li>
+              <p>Unsupported codec changes occur across <a href="#init-segment">initialization segments</a>.</p>
+              <div class="note" id="issue-container-generatedID-77"><div role="heading" class="note-title marker" id="h-note-77" aria-level="3"><span>Note</span></div><p class="">See the <a href="#sourcebuffer-init-segment-received">initialization segment received algorithm</a>, <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> and <code><a href="#dom-sourcebuffer-changetype">changeType()</a></code> for details and examples of codec changes.</p></div>
+            </li>
+          </ol>
+        </li>
+        <li>The user agent <em class="rfc2119" title="MUST">MUST</em> support the following:
+          <ol>
+            <li><a href="#track-id">Track IDs</a> changing across <a href="#init-segment">initialization segments</a> if the segments describes only one track of each type.</li>
+            <li>
+              <p>Video frame size changes. The user agent <em class="rfc2119" title="MUST">MUST</em> support seamless playback.</p>
+              <div class="note" id="issue-container-generatedID-78"><div role="heading" class="note-title marker" id="h-note-78" aria-level="3"><span>Note</span></div><p class="">This will cause the &lt;video&gt; display region to change size if the web application does not use CSS or HTML attributes (width/height) to constrain the element size.</p></div>
+            </li>
+            <li>
+              <p>Audio channel count changes. The user agent <em class="rfc2119" title="MAY">MAY</em> support this seamlessly and could trigger downmixing.</p>
+              <div class="note" id="issue-container-generatedID-79"><div role="heading" class="note-title marker" id="h-note-79" aria-level="3"><span>Note</span></div><p class="">This is a quality of implementation issue because changing the channel count may require reinitializing the audio device, resamplers, and channel mixers which tends to be audible.</p></div>
+            </li>
+          </ol>
+        </li>
+        <li>The following rules apply to all <a href="#media-segment">media segments</a> within a byte stream. A user agent <em class="rfc2119" title="MUST">MUST</em>:
+          <ol>
+            <li>Map all timestamps to the same <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-timeline">media timeline</a>.</li>
+            <li>Support seamless playback of <a href="#media-segment">media segments</a> having a timestamp gap smaller than the audio frame size. User agents <em class="rfc2119" title="MUST NOT">MUST NOT</em> reflect these gaps in the <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> attribute.
+              <div class="note" id="issue-container-generatedID-80"><div role="heading" class="note-title marker" id="h-note-80" aria-level="3"><span>Note</span></div><p class="">This is intended to simplify switching between audio streams where the frame boundaries don't always line up across encodings (e.g., Vorbis).</p></div>
+            </li>
+          </ol>
+        </li>
+        <li>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> when any combination of an <a href="#init-segment">initialization segment</a> and any contiguous sequence of <a href="#media-segment">media segments</a> satisfies the
+          following conditions:
+          <ol>
+            <li>The number and type (audio, video, text, etc.) of all tracks in the <a href="#media-segment">media segments</a> are not identified.</li>
+            <li>The decoding capabilities needed to decode each track (i.e., codec and codec parameters) are not provided.</li>
+            <li>Encryption parameters necessary to decrypt the content (except the encryption key itself) are not provided for all encrypted tracks.</li>
+            <li>All information necessary to decode and render the earliest <a href="#random-access-point">random access point</a> in the sequence of <a href="#media-segment">media segments</a> and all subsequence samples in the sequence
+              (in presentation time) are not provided. This includes in particular,
+              <ul>
+                <li>Information that determines the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#video-intrinsic-width">intrinsic width and height</a> of the video (specifically, this requires either the picture or pixel aspect ratio, together with the encoded
+                  resolution).</li>
+                <li>Information necessary to convert the video decoder output to a format suitable for display</li>
+              </ul>
+            </li>
+            <li>Information necessary to compute the global <a href="#presentation-timestamp">presentation timestamp</a> of every sample in the sequence of <a href="#media-segment">media segments</a> is not provided.</li>
+          </ol>
+          <p>For example, if I1 is associated with M1, M2, M3 then the above <em class="rfc2119" title="MUST">MUST</em> hold for all the combinations I1+M1, I1+M2, I1+M1+M2, I1+M2+M3, etc.</p>
+        </li>
+      </ul>
+      <p>Byte stream specifications <em class="rfc2119" title="MUST">MUST</em> at a minimum define constraints which ensure that the above requirements hold. Additional constraints <em class="rfc2119" title="MAY">MAY</em> be defined, for example to simplify implementation.</p>
 
-      <section typeof="bibo:Chapter" resource="#attributes-5" property="bibo:hasPart">
-        <h3 id="attributes-5" resource="#attributes-5"><span property="xhv:role" resource="xhv:heading">Attributes</span></h3>
-        <dl class="attributes" data-dfn-for="TextTrack" data-link-for="TextTrack"><dt><dfn data-dfn-for="texttrack" data-dfn-type="dfn" id="dom-texttrack-sourcebuffer" data-idl=""><code>sourceBuffer</code></dfn> of type <span class="idlAttrType"><a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a></span>, readonly       , nullable</dt>
-          <dd>
-            <p>Returns the <a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> that created this track. Returns null if this track was not created by a <a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> or the <a href="#dom-texttrack-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> has been removed from the <code><a href="#dom-mediasource-sourcebuffers">sourceBuffers</a></code> attribute of its <a href="#parent-media-source">parent media source</a>.</p>
-          </dd>
-        </dl>
-      </section>
-    </div>
-  </section>
+    </section>
 
-  <section id="byte-stream-formats" typeof="bibo:Chapter" resource="#byte-stream-formats" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-byte-stream-formats" resource="#h-byte-stream-formats"><span property="xhv:role" resource="xhv:heading"><span class="secno">10. </span>Byte Stream Formats</span>
-    </h2>
-    <p>The bytes provided through <code><a href="#dom-sourcebuffer-appendbuffer">appendBuffer()</a></code> for a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> form a logical byte stream. The format and semantics of these byte streams are defined in <dfn id="byte-stream-format-specs" data-dfn-type="dfn">byte stream format specifications</dfn>. The byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] provides mappings between a MIME type that may be passed to <code><a href="#dom-mediasource-addsourcebuffer">addSourceBuffer()</a></code> or
-      <code><a href="#dom-mediasource-istypesupported">isTypeSupported()</a></code> and the byte stream format expected by a <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> created with that MIME type. Implementations are encouraged to register mappings for byte stream formats they support to facilitate interoperability. The byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] is the authoritative source for these mappings. If an implementation claims to support a MIME type listed in the registry, its <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> implementation <em class="rfc2119" title="MUST">MUST</em> conform to the
-      <a href="#byte-stream-format-specs">byte stream format specification</a> listed in the registry entry.</p>
-    <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note74"><span>Note</span></div>
-      <p class="">The byte stream format specifications in the registry are not intended to define new storage formats. They simply outline the subset of existing storage format structures that implementations of this specification will accept.</p>
-    </div>
-    <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note75"><span>Note</span></div>
-      <p class="">Byte stream format parsing and validation is implemented in the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</p>
-    </div>
+    <section id="conformance"><!--OddPage--><h2 id="x11-conformance"><span class="secno">11. </span>Conformance</h2><p>
+  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
+  and notes in this specification are non-normative. Everything else in this specification is
+  normative.
+</p><p id="respecRFC2119">The key words  <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">SHOULD</em>, and <em class="rfc2119">SHOULD NOT</em> are 
+  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+</p></section>
 
-    <p>This section provides general requirements for all byte stream format specifications:</p>
-    <ul>
-      <li>A byte stream format specification <em class="rfc2119" title="MUST">MUST</em> define <a href="#init-segment">initialization segments</a> and <a href="#media-segment">media segments</a>.</li>
-      <li>A byte stream format <em class="rfc2119" title="SHOULD">SHOULD</em> provide references for sourcing <a href="#idl-def-audiotrack-partial-1" class="internalDFN" data-link-type="dfn"><code>AudioTrack</code></a>, <a href="#idl-def-videotrack-partial-1" class="internalDFN" data-link-type="dfn"><code>VideoTrack</code></a>, and <a href="#idl-def-texttrack-partial-1" class="internalDFN" data-link-type="dfn"><code>TextTrack</code></a> attribute values from data in <a href="#init-segment">initialization segments</a>.
-        <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note76"><span>Note</span></div>
-          <p class="">If the byte stream format covers a format similar to one covered in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>], then it <em class="rfc2119" title="SHOULD">SHOULD</em> try to use the same attribute mappings so that Media Source Extensions playback and non-Media Source Extensions playback provide the same track information.</p>
-        </div>
-      </li>
-      <li>It <em class="rfc2119" title="MUST">MUST</em> be possible to identify segment boundaries and segment type (initialization or media) by examining the byte stream alone.</li>
-      <li>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> when any of the following conditions are met:
-        <ol>
-          <li>
-            <p>The number and type of tracks are not consistent.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note77"><span>Note</span></div>
-              <p class="">For example, if the first <a href="#init-segment">initialization segment</a> has 2 audio tracks and 1 video track, then all <a href="#init-segment">initialization segments</a> that follow it in the byte stream <em class="rfc2119" title="MUST">MUST</em> describe 2 audio tracks and 1 video track.</p>
-            </div>
-          </li>
-          <li><a href="#track-id">Track IDs</a> are not the same across <a href="#init-segment">initialization segments</a>, for segments describing multiple tracks of a single type (e.g., 2 audio tracks).</li>
-          <li>
-            <p>Codecs changes across <a href="#init-segment">initialization segments</a>.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note78"><span>Note</span></div>
-              <p class="">For example, a byte stream that starts with an <a href="#init-segment">initialization segment</a> that specifies a single AAC track and later contains an <a href="#init-segment">initialization segment</a> that specifies a single AMR-WB track is not allowed. Support for multiple codecs is handled with multiple <a href="#idl-def-sourcebuffer" class="internalDFN" data-link-type="dfn"><code>SourceBuffer</code></a> objects.</p>
-            </div>
-          </li>
-        </ol>
-      </li>
-      <li>The user agent <em class="rfc2119" title="MUST">MUST</em> support the following:
-        <ol>
-          <li><a href="#track-id">Track IDs</a> changing across <a href="#init-segment">initialization segments</a> if the segments describes only one track of each type.</li>
-          <li>
-            <p>Video frame size changes. The user agent <em class="rfc2119" title="MUST">MUST</em> support seamless playback.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note79"><span>Note</span></div>
-              <p class="">This will cause the &lt;video&gt; display region to change size if the web application does not use CSS or HTML attributes (width/height) to constrain the element size.</p>
-            </div>
-          </li>
-          <li>
-            <p>Audio channel count changes. The user agent <em class="rfc2119" title="MAY">MAY</em> support this seamlessly and could trigger downmixing.</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note80"><span>Note</span></div>
-              <p class="">This is a quality of implementation issue because changing the channel count may require reinitializing the audio device, resamplers, and channel mixers which tends to be audible.</p>
-            </div>
-          </li>
-        </ol>
-      </li>
-      <li>The following rules apply to all <a href="#media-segment">media segments</a> within a byte stream. A user agent <em class="rfc2119" title="MUST">MUST</em>:
-        <ol>
-          <li>Map all timestamps to the same <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-timeline">media timeline</a>.</li>
-          <li>Support seamless playback of <a href="#media-segment">media segments</a> having a timestamp gap smaller than the audio frame size. User agents <em class="rfc2119" title="MUST NOT">MUST NOT</em> reflect these gaps in the <code><a href="#dom-sourcebuffer-buffered">buffered</a></code> attribute.
-            <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note81"><span>Note</span></div>
-              <p class="">This is intended to simplify switching between audio streams where the frame boundaries don't always line up across encodings (e.g., Vorbis).</p>
-            </div>
-          </li>
-        </ol>
-      </li>
-      <li>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="#sourcebuffer-append-error">append error algorithm</a> when any combination of an <a href="#init-segment">initialization segment</a> and any contiguous sequence of <a href="#media-segment">media segments</a> satisfies the following conditions:
-        <ol>
-          <li>The number and type (audio, video, text, etc.) of all tracks in the <a href="#media-segment">media segments</a> are not identified.</li>
-          <li>The decoding capabilities needed to decode each track (i.e., codec and codec parameters) are not provided.</li>
-          <li>Encryption parameters necessary to decrypt the content (except the encryption key itself) are not provided for all encrypted tracks.</li>
-          <li>All information necessary to decode and render the earliest <a href="#random-access-point">random access point</a> in the sequence of <a href="#media-segment">media segments</a> and all subsequence samples in the sequence (in presentation time) are not provided. This includes in particular,
-            <ul>
-              <li>Information that determines the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#video-intrinsic-width">intrinsic width and height</a> of the video (specifically, this requires either the picture or pixel aspect ratio, together with the encoded resolution).
-              </li>
-              <li>Information necessary to convert the video decoder output to a format suitable for display</li>
-            </ul>
-          </li>
-          <li>Information necessary to compute the global <a href="#presentation-timestamp">presentation timestamp</a> of every sample in the sequence of <a href="#media-segment">media segments</a> is not provided.</li>
-        </ol>
-        <p>For example, if I1 is associated with M1, M2, M3 then the above <em class="rfc2119" title="MUST">MUST</em> hold for all the combinations I1+M1, I1+M2, I1+M1+M2, I1+M2+M3, etc.</p>
-      </li>
-    </ul>
-    <p>Byte stream specifications <em class="rfc2119" title="MUST">MUST</em> at a minimum define constraints which ensure that the above requirements hold. Additional constraints <em class="rfc2119" title="MAY">MAY</em> be defined, for example to simplify implementation.</p>
+    <section id="examples">
+      <!--OddPage--><h2 id="x12-examples"><span class="secno">12. </span>Examples</h2>
+      <p>Example use of the Media Source Extensions</p>
+      <div class="block">
+        <div class="blockContent">
+          <pre class="code hljs" aria-busy="false">&lt;script&gt;
+  function onSourceOpen(videoTag, e) {
+    var mediaSource = e.target;
 
-  </section>
+    if (mediaSource.sourceBuffers.length &gt; 0)
+        return;
 
-  <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">11. </span>Conformance</span>
-    </h2>
-    <p>
-      As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
-    </p>
-    <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
-    </p>
-  </section>
+    var sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vorbis,vp8"');
 
-  <section id="examples" typeof="bibo:Chapter" resource="#examples" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-examples" resource="#h-examples"><span property="xhv:role" resource="xhv:heading"><span class="secno">12. </span>Examples</span>
-    </h2>
-    <p>Example use of the Media Source Extensions</p>
-    <div class="block">
-      <div class="blockContent">
-        <pre class="code hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">onSourceOpen</span>(<span class="hljs-params">videoTag, e</span>) </span>{
-    <span class="hljs-keyword">var</span> mediaSource = e.target;
+    videoTag.addEventListener('seeking', onSeeking.bind(videoTag, mediaSource));
+    videoTag.addEventListener('progress', onProgress.bind(videoTag, mediaSource));
 
-    <span class="hljs-keyword">if</span> (mediaSource.sourceBuffers.length &gt; <span class="hljs-number">0</span>)
-        <span class="hljs-keyword">return</span>;
+    var initSegment = GetInitializationSegment();
 
-    <span class="hljs-keyword">var</span> sourceBuffer = mediaSource.addSourceBuffer(<span class="hljs-string">'video/webm; codecs="vorbis,vp8"'</span>);
-
-    videoTag.addEventListener(<span class="hljs-string">'seeking'</span>, onSeeking.bind(videoTag, mediaSource));
-    videoTag.addEventListener(<span class="hljs-string">'progress'</span>, onProgress.bind(videoTag, mediaSource));
-
-    <span class="hljs-keyword">var</span> initSegment = GetInitializationSegment();
-
-    <span class="hljs-keyword">if</span> (initSegment == <span class="hljs-literal">null</span>) {
-      <span class="hljs-comment">// Error fetching the initialization segment. Signal end of stream with an error.</span>
-      mediaSource.endOfStream(<span class="hljs-string">"network"</span>);
-      <span class="hljs-keyword">return</span>;
+    if (initSegment == null) {
+      // Error fetching the initialization segment. Signal end of stream with an error.
+      mediaSource.endOfStream("network");
+      return;
     }
 
-    <span class="hljs-comment">// Append the initialization segment.</span>
-    <span class="hljs-keyword">var</span> firstAppendHandler = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">e</span>) </span>{
-      <span class="hljs-keyword">var</span> sourceBuffer = e.target;
-      sourceBuffer.removeEventListener(<span class="hljs-string">'updateend'</span>, firstAppendHandler);
+    // Append the initialization segment.
+    var firstAppendHandler = function(e) {
+      var sourceBuffer = e.target;
+      sourceBuffer.removeEventListener('updateend', firstAppendHandler);
 
-      <span class="hljs-comment">// Append some initial media data.</span>
+      // Append some initial media data.
       appendNextMediaSegment(mediaSource);
     };
-    sourceBuffer.addEventListener(<span class="hljs-string">'updateend'</span>, firstAppendHandler);
+    sourceBuffer.addEventListener('updateend', firstAppendHandler);
     sourceBuffer.appendBuffer(initSegment);
   }
 
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">appendNextMediaSegment</span>(<span class="hljs-params">mediaSource</span>) </span>{
-    <span class="hljs-keyword">if</span> (mediaSource.readyState == <span class="hljs-string">"closed"</span>)
-      <span class="hljs-keyword">return</span>;
+  function appendNextMediaSegment(mediaSource) {
+    if (mediaSource.readyState == "closed")
+      return;
 
-    <span class="hljs-comment">// If we have run out of stream data, then signal end of stream.</span>
-    <span class="hljs-keyword">if</span> (!HaveMoreMediaSegments()) {
+    // If we have run out of stream data, then signal end of stream.
+    if (!HaveMoreMediaSegments()) {
       mediaSource.endOfStream();
-      <span class="hljs-keyword">return</span>;
+      return;
     }
 
-    <span class="hljs-comment">// Make sure the previous append is not still pending.</span>
-    <span class="hljs-keyword">if</span> (mediaSource.sourceBuffers[<span class="hljs-number">0</span>].updating)
-        <span class="hljs-keyword">return</span>;
+    // Make sure the previous append is not still pending.
+    if (mediaSource.sourceBuffers[0].updating)
+        return;
 
-    <span class="hljs-keyword">var</span> mediaSegment = GetNextMediaSegment();
+    var mediaSegment = GetNextMediaSegment();
 
-    <span class="hljs-keyword">if</span> (!mediaSegment) {
-      <span class="hljs-comment">// Error fetching the next media segment.</span>
-      mediaSource.endOfStream(<span class="hljs-string">"network"</span>);
-      <span class="hljs-keyword">return</span>;
+    if (!mediaSegment) {
+      // Error fetching the next media segment.
+      mediaSource.endOfStream("network");
+      return;
     }
 
-    <span class="hljs-comment">// <span class="hljs-doctag">NOTE:</span> If mediaSource.readyState == “ended”, this appendBuffer() call will</span>
-    <span class="hljs-comment">// cause mediaSource.readyState to transition to "open". The web application</span>
-    <span class="hljs-comment">// should be prepared to handle multiple “sourceopen” events.</span>
-    mediaSource.sourceBuffers[<span class="hljs-number">0</span>].appendBuffer(mediaSegment);
+    // NOTE: If mediaSource.readyState == “ended”, this appendBuffer() call will
+    // cause mediaSource.readyState to transition to "open". The web application
+    // should be prepared to handle multiple “sourceopen” events.
+    mediaSource.sourceBuffers[0].appendBuffer(mediaSegment);
   }
 
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">onSeeking</span>(<span class="hljs-params">mediaSource, e</span>) </span>{
-    <span class="hljs-keyword">var</span> video = e.target;
+  function onSeeking(mediaSource, e) {
+    var video = e.target;
 
-    <span class="hljs-keyword">if</span> (mediaSource.readyState == <span class="hljs-string">"open"</span>) {
-      <span class="hljs-comment">// Abort current segment append.</span>
-      mediaSource.sourceBuffers[<span class="hljs-number">0</span>].abort();
+    if (mediaSource.readyState == "open") {
+      // Abort current segment append.
+      mediaSource.sourceBuffers[0].abort();
     }
 
-    <span class="hljs-comment">// Notify the media segment loading code to start fetching data at the</span>
-    <span class="hljs-comment">// new playback position.</span>
+    // Notify the media segment loading code to start fetching data at the
+    // new playback position.
     SeekToMediaSegmentAt(video.currentTime);
 
-    <span class="hljs-comment">// Append a media segment from the new playback position.</span>
+    // Append a media segment from the new playback position.
     appendNextMediaSegment(mediaSource);
   }
 
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">onProgress</span>(<span class="hljs-params">mediaSource, e</span>) </span>{
+  function onProgress(mediaSource, e) {
     appendNextMediaSegment(mediaSource);
   }
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
+&lt;/script&gt;
 
-<span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"v"</span> <span class="hljs-attr">autoplay</span>&gt;</span> <span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span>
+&lt;video id="v" autoplay&gt; &lt;/video&gt;
 
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-keyword">var</span> video = <span class="hljs-built_in">document</span>.getElementById(<span class="hljs-string">'v'</span>);
-  <span class="hljs-keyword">var</span> mediaSource = <span class="hljs-keyword">new</span> MediaSource();
-  mediaSource.addEventListener(<span class="hljs-string">'sourceopen'</span>, onSourceOpen.bind(<span class="hljs-keyword">this</span>, video));
-  video.src = <span class="hljs-built_in">window</span>.URL.createObjectURL(mediaSource);
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
+&lt;script&gt;
+  var video = document.getElementById('v');
+  var mediaSource = new MediaSource();
+  mediaSource.addEventListener('sourceopen', onSourceOpen.bind(this, video));
+  video.src = window.URL.createObjectURL(mediaSource);
+&lt;/script&gt;
           </pre>
+        </div>
       </div>
-    </div>
-  </section>
-
-  <section id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">13. </span>Acknowledgments</span>
-    </h2>
-    The editors would like to thank Alex Giladi, Bob Lund, Chris Poole, Cyril Concolato, David Dorwin, David Singer, Duncan Rowden, Frank Galligan, Glenn Adams, Jer Noble, Joe Steele, John Simmons, Kevin Streeter, Mark Vickers, Matt Ward, Matthew Gregan, Michael Thornburgh, Philip Jägenstedt, Pierre Lemieux, Ralph Giles, Steven Robertson, and Tatsuya Igarashi for their contributions to this specification.
-  </section>
-
-  <section id="VideoPlaybackQuality" class="appendix informative" typeof="bibo:Chapter" resource="#VideoPlaybackQuality" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-videoplaybackquality" resource="#h-videoplaybackquality"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>VideoPlaybackQuality</span>
-    </h2>
-    <p><em>This section is non-normative.</em></p>
-    The video playback quality metrics described in previous revisions of this specification (e.g., sections 5 and 10 of the <a href="https://www.w3.org/TR/2016/CR-media-source-20160705/">Candidate Recommendation</a>) are now being developed as part of [<cite><a class="bibref" href="#bib-MEDIA-PLAYBACK-QUALITY">MEDIA-PLAYBACK-QUALITY</a></cite>]. Some implementations may have implemented the earlier draft <code>VideoPlaybackQuality</code> object and the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlvideoelement-htmlvideoelement">HTMLVideoElement</a></code> extension method <code>getVideoPlaybackQuality()</code> described in those previous revisions.
-  </section>
-
-
-  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
-    <!--OddPage-->
-    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>References</span>
-    </h2>
-
-    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
-      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Normative references</span>
-      </h3>
-      <dl class="bibliography" resource=""><dt id="bib-FILE-API">[FILE-API]</dt>
-        <dd>Arun Ranganathan; Jonas Sicking. W3C. <a href="https://www.w3.org/TR/FileAPI/" property="dc:requires"><cite>File API</cite></a>. 21 April 2015. W3C Working Draft. URL: <a href="https://www.w3.org/TR/FileAPI/" property="dc:requires">https://www.w3.org/TR/FileAPI/</a>
-        </dd><dt id="bib-HTML51">[HTML51]</dt>
-        <dd>Steve Faulkner; Arron Eicholz; Travis Leithead; Alex Danilo. W3C. <a href="https://www.w3.org/TR/html51/" property="dc:requires"><cite>HTML 5.1</cite></a>. 1 November 2016. W3C Recommendation. URL: <a href="https://www.w3.org/TR/html51/" property="dc:requires">https://www.w3.org/TR/html51/</a>
-        </dd><dt id="bib-RFC2119">[RFC2119]</dt>
-        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
-        </dd><dt id="bib-WEBIDL">[WEBIDL]</dt>
-        <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. <a href="https://www.w3.org/TR/WebIDL-1/" property="dc:requires"><cite>Web IDL</cite></a>. 15 September 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/WebIDL-1/" property="dc:requires">https://www.w3.org/TR/WebIDL-1/</a>
-        </dd>
-      </dl>
     </section>
 
-    <section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart">
-      <h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.2 </span>Informative references</span>
-      </h3>
-      <dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt>
-        <dd>Bob Lund; Silvia Pfeiffer. W3C. <a href="https://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="https://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">https://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
-        </dd><dt id="bib-MEDIA-PLAYBACK-QUALITY">[MEDIA-PLAYBACK-QUALITY]</dt>
-        <dd>Mounir Lamouri. W3C. <a href="https://wicg.github.io/media-playback-quality/" property="dc:references"><cite>Media Playback Quality</cite></a>. URL: <a href="https://wicg.github.io/media-playback-quality/" property="dc:references">https://wicg.github.io/media-playback-quality/</a>
-        </dd><dt id="bib-MSE-REGISTRY">[MSE-REGISTRY]</dt>
-        <dd>Matthew Wolenetz; Jerry Smith; Aaron Colwell. W3C. <a href="byte-stream-format-registry.html" property="dc:references"><cite>Media Source Extensions Byte Stream Format Registry</cite></a>. URL: <a href="byte-stream-format-registry.html" property="dc:references">byte-stream-format-registry.html</a>
-        </dd>
-      </dl>
+    <section id="acknowledgements">
+      <!--OddPage--><h2 id="x13-acknowledgments"><span class="secno">13. </span>Acknowledgments</h2>
+      The editors would like to thank Alex Giladi, Bob Lund, Chris Poole, Cyril Concolato, David Dorwin, David Singer, Duncan Rowden, Frank Galligan, Glenn Adams, Jer Noble, Joe Steele, John Simmons, Kevin Streeter, Mark Vickers, Matt Ward, Matthew Gregan, Michael Thornburgh, Philip Jägenstedt, Pierre Lemieux, Ralph Giles, Steven Robertson, and Tatsuya Igarashi for their contributions to this specification.
     </section>
-  </section>
-  <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p>
-  <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
-</body>
-</html>
+
+    <section id="VideoPlaybackQuality" class="appendix informative">
+      <!--OddPage--><h2 id="a-videoplaybackquality"><span class="secno">A. </span>VideoPlaybackQuality</h2><p><em>This section is non-normative.</em></p>
+      The video playback quality metrics described in previous revisions of this specification (e.g., sections 5 and 10 of the <a href="https://www.w3.org/TR/2016/CR-media-source-20160705/">Candidate Recommendation</a>) are now being developed as part of [<cite><a class="bibref" href="#bib-MEDIA-PLAYBACK-QUALITY">MEDIA-PLAYBACK-QUALITY</a></cite>]. Some implementations may have implemented the earlier draft <code>VideoPlaybackQuality</code> object and the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlvideoelement-htmlvideoelement">HTMLVideoElement</a></code> extension method <code>getVideoPlaybackQuality()</code> described in those previous revisions.
+    </section>
+  
+
+<section id="references" class="appendix"><!--OddPage--><h2 id="b-references"><span class="secno">B. </span>References</h2><section id="normative-references"><h3 id="b-1-normative-references"><span class="secno">B.1 </span>Normative references</h3><dl class="bibliography"><dt id="bib-FILE-API">[FILE-API]</dt><dd><a href="https://www.w3.org/TR/FileAPI/"><cite>File API</cite></a>. Marijn Kruisselbrink. W3C. 26 October 2017. W3C Working Draft. URL: <a href="https://www.w3.org/TR/FileAPI/">https://www.w3.org/TR/FileAPI/</a>
+</dd><dt id="bib-HTML51">[HTML51]</dt><dd><a href="https://www.w3.org/TR/html51/"><cite>HTML 5.1 2nd Edition</cite></a>. Steve Faulkner; Arron Eicholz; Travis Leithead; Alex Danilo. W3C. 3 October 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a>
+</dd><dt id="bib-RFC2119">[RFC2119]</dt><dd><a href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner. IETF. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+</dd><dt id="bib-WEBIDL">[WEBIDL]</dt><dd><a href="https://heycam.github.io/webidl/"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+</dd></dl></section><section id="informative-references"><h3 id="b-2-informative-references"><span class="secno">B.2 </span>Informative references</h3><dl class="bibliography"><dt id="bib-HTML">[HTML]</dt><dd><a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters. WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+</dd><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd><a href="https://dev.w3.org/html5/html-sourcing-inband-tracks/"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. Bob Lund; Silvia Pfeiffer. W3C. URL: <a href="https://dev.w3.org/html5/html-sourcing-inband-tracks/">https://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
+</dd><dt id="bib-MEDIA-PLAYBACK-QUALITY">[MEDIA-PLAYBACK-QUALITY]</dt><dd><a href="https://wicg.github.io/media-playback-quality/"><cite>Media Playback Quality</cite></a>. Mounir Lamouri. W3C. URL: <a href="https://wicg.github.io/media-playback-quality/">https://wicg.github.io/media-playback-quality/</a>
+</dd><dt id="bib-MSE-REGISTRY">[MSE-REGISTRY]</dt><dd><a href="byte-stream-format-registry.html"><cite>Media Source Extensions™ Byte Stream Format Registry</cite></a>. Matthew Wolenetz; Jerry Smith; Aaron Colwell. W3C. URL: <a href="byte-stream-format-registry.html">byte-stream-format-registry.html</a>
+</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Media Source Extensions™</title>
+    <title>Media Source Extensions™ - Codec Switching feature incubation</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
     <!--<script src="respec-w3c-common.js" class="remove"></script>-->
     <script src="media-source.js" class="remove"></script>
@@ -180,10 +180,13 @@
     </section>
 
     <section id="abstract">
-      This specification extends <a def-id="htmlmediaelement">HTMLMediaElement</a> [[!HTML51]] to allow
+      <p>This specification extends <a def-id="htmlmediaelement">HTMLMediaElement</a> [[!HTML51]] to allow
       JavaScript to generate media streams for playback.
       Allowing JavaScript to generate streams facilitates a variety of use
-      cases like adaptive streaming and time shifting live streams.
+      cases like adaptive streaming and time shifting live streams.</p>
+
+      <p>This version of the specification is intended for incubating a new codec switching feature, as
+      outlined in <a href='https://github.com/wicg/media-source/blob/codec-switching/codec-switching-explainer.md'>the Codec Switching Explainer</a>.</p>
     </section>
 
     <section id="introduction" class="informative">
@@ -296,8 +299,8 @@
 
           <dt id="sourcebuffer-byte-stream-format-spec">SourceBuffer byte stream format specification</dt>
           <dd><p>The specific <a def-id="byte-stream-format-spec"></a> that describes the format of the byte stream accepted by a <a>SourceBuffer</a> instance. The
-              <a def-id="byte-stream-format-spec"></a>, for a <a>SourceBuffer</a> object, is selected based on the <var>type</var> passed to the
-              <a def-id="addSourceBuffer"></a> call that created the object.</p></dd>
+              <a def-id="byte-stream-format-spec"></a>, for a <a>SourceBuffer</a> object, is initially selected based on the <var>type</var> passed to the
+              <a def-id="addSourceBuffer"></a> call that created the object, and can be updated by <a def-id="changeType"></a> calls on the object.</p></dd>
 
           <dt id="sourcebuffer-configuration">SourceBuffer configuration</dt>
           <dd><p>A specific set of tracks distributed across one or more <a>SourceBuffer</a>
@@ -969,9 +972,12 @@ interface MediaSource : EventTarget {
                     attribute EventHandler        onabort;
     void appendBuffer (BufferSource data);
     void abort ();
+    void changeType (DOMString type);
     void remove (double start, unrestricted double end);
-};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer"><dt><dfn><code>mode</code></dfn> of type <span class="idlAttrType"><a>AppendMode</a></span></dt><dd>
-          <p>Controls how a sequence of <a def-id="media-segments"></a> are handled. This attribute is initially set by <a def-id="addSourceBuffer"></a> after the object is created.</p>
+};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer">
+        <dt><dfn><code>mode</code></dfn> of type <span class="idlAttrType"><a>AppendMode</a></span></dt>
+        <dd>
+          <p>Controls how a sequence of <a def-id="media-segments"></a> are handled. This attribute is initially set by <a def-id="addSourceBuffer"></a> after the object is created, and can be updated by <a def-id="changeType"></a> or setting this attribute.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
           <ol>
@@ -1107,7 +1113,58 @@ interface MediaSource : EventTarget {
             <li>Set <a def-id="appendWindowStart"></a> to the <a def-id="presentation-start-time"></a>.</li>
             <li>Set <a def-id="appendWindowEnd"></a> to positive Infinity.</li>
           </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><a>void</a></div></dd><dt><dfn><code>remove</code></dfn></dt><dd>
+        <div>
+          <dt><dfn><code>changeType</code></dfn></dt><dd>
+          <p>Changes the MIME type associated with this object. Subsequent <a def-id="appendBuffer"></a> calls will expect the newly appended bytes to conform to the new type.</a>
+          <ol class="method-algorithm">
+            <li>If <var>type</var> is an empty string then throw a <a def-id="type-error"></a> exception and abort these steps.</li>
+            <li>If this object has been removed from the <a def-id="sourceBuffers"></a> attribute of the <a def-id="parent-media-source"></a>, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the <a def-id="updating"></a> attribute equals true, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If <var>type</var> contains a MIME type that is not supported or contains a MIME type that is not supported with the types specified (currently or previously) of <a>SourceBuffer</a> objects in the <a def-id="sourceBuffers"></a> attribute of the <a def-id="parent-media-source"></a>, then throw a <a def-id="not-supported-error"></a> exception and abort these steps.</li>
+            <li>
+              <p>If the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
+              <ol>
+                <li>Set the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
+                <li><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceopen"></a> at the <a def-id="parent-media-source"></a>.</li>
+              </ol>
+            </li>
+            <li>Run the <a def-id="reset-parser-state-algorithm"></a>.</li>
+            <li>Update the <a def-id="generate-timestamps-flag"></a> on this <a>SourceBuffer</a> object to the value in the
+                 "Generate Timestamps Flag" column of the byte stream format registry [[MSE-REGISTRY]] entry
+                 that is associated with <var>type</var>.</li>
+            <li>
+                <dl class="switch">
+                  <dt>If the <a def-id="generate-timestamps-flag"></a> equals true:</dt>
+                  <dd>
+                    Set the <a def-id="mode"></a> attribute on this <a>SourceBuffer</a> object to <a def-id="AppendMode-sequence"></a>, including running the associated steps for that attribute being set.
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    Keep the previous value of the <a def-id="mode"></a> attribute on this <a>SourceBuffer</a> object, without running any associated steps for that attribute being set.
+                  </dd>
+                </dl>
+            </li>
+            <li>Set <a def-id="pending-init-segment-for-changetype-flag"></a> to true.
+          </ol>
+          <table class="parameters">
+            <tbody>
+              <tr>
+                <th>Parameter</th>
+                <th>Type</th>
+                <th>Nullable</th>
+                <th>Optional</th>
+                <th>Description</th>
+              </tr>
+              <tr>
+                <td class="prmName">type</td>
+                <td class="prmType"><code>DOMString</code></td>
+                <td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td>
+                <td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td>
+                <td class="prmDesc"></td>
+              </tr>
+            </tbody>
+          </table>
+        <dt><dfn><code>remove</code></dfn></dt><dd>
         <p>Removes media for a specific time range.</p>
         <ol class="method-algorithm">
             <li>If this object has been removed from the <a def-id="sourceBuffers"></a> attribute of the <a def-id="parent-media-source"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
@@ -1315,7 +1372,7 @@ interface MediaSource : EventTarget {
             <li>
               <p>If the <a def-id="append-state"></a> equals <a def-id="parsing-media-segment"></a>, then run the following steps:</p>
               <ol>
-                <li>If the <a def-id="first-init-segment-received-flag"></a> is false, then run the <a def-id="append-decode-error-algorithm"></a> and abort this algorithm.</li>
+                <li>If the <a def-id="first-init-segment-received-flag"></a> is false or the <a def-id="pending-init-segment-for-changetype-flag"></a> is true, then run the <a def-id="append-decode-error-algorithm"></a> and abort this algorithm.</li>
                 <li>If the <a def-id="input-buffer"></a> contains one or more complete <a def-id="coded-frames"></a>, then run the
                   <a def-id="coded-frame-processing-algorithm"></a>.
                   <p class="note">
@@ -1421,7 +1478,15 @@ interface MediaSource : EventTarget {
         <section id="sourcebuffer-init-segment-received">
           <h4>Initialization Segment Received</h4>
           <p>The following steps are run when the <a def-id="segment-parser-loop"></a> successfully parses a complete <a def-id="init-segment"></a>:</p>
-          <p>Each SourceBuffer object has an internal <dfn id="first-init-segment-received-flag">first initialization segment received flag</dfn> that tracks whether the first <a def-id="init-segment"></a> has been appended and received by this algorithm. This flag is set to false when the SourceBuffer is created and updated by the algorithm below.</p>
+          <p>Each <a>SourceBuffer</a> object has an internal <dfn id="first-init-segment-received-flag">
+            first initialization segment received flag</dfn> that tracks whether the first <a def-id="init-segment"></a>
+            has been appended and received by this algorithm.
+            This flag is set to false when the SourceBuffer is created and is updated by the algorithm below.</p>
+          <p>Each <a>SourceBuffer</a> object has an internal <dfn id="pending-init-segment-for-changetype-flag">
+            pending initialization segment for changeType flag</dfn> that tracks whether an <a def-id="init-segment"></a>
+            is needed since the most recent <a def-id="changeType"></a>.
+            This flag is set to false when the SourceBuffer is created, set to true by <a def-id="changeType"></a> and reset to false
+            by the algorithm below.</p>
           <ol>
             <li>Update the <a def-id="duration"></a> attribute if it currently equals NaN:
               <dl class="switch">
@@ -1437,9 +1502,20 @@ interface MediaSource : EventTarget {
                 <li>Verify the following properties. If any of the checks fail then run the <a def-id="append-decode-error-algorithm"></a> and abort these steps.
                   <ul>
                     <li>The number of audio, video, and text tracks match what was in the first <a def-id="init-segment"></a>.</li>
-                    <li>The codecs for each track, match what was specified in the first <a def-id="init-segment"></a>.</li>
                     <li>If more than one track for a single type are present (e.g., 2 audio tracks), then the <a def-id="track-ids"></a> match the ones in the
                       first <a def-id="init-segment"></a>.</li>
+                    <li>The codecs for each track are supported by the user agent.
+                      <p class="note">User agents MAY consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not
+                        specified in <var>type</var> parameter passed to
+                        (a) the most recently successful <a def-id="changeType"></a> on this <a>SourceBuffer</a> object, or
+                        (b) if no successful <a def-id="changeType"></a> has yet occurred on this object, the <a def-id="addSourceBuffer"></a> that created this <a>SourceBuffer</a> object.
+                        For example, if the most recently successful <a def-id="changeType"></a> was called with 'video/webm'
+                        or 'video/webm; codecs="vp8"', and a video track containing vp9 appears in the initialization segment,
+                        then the user agent MAY use this step to trigger a decode error even if the other two properties'
+                        checks, above, pass. Implementations are encouraged to trigger error in such cases only when the codec
+                        is indeed not supported or the other two properties' checks fail.
+                      </p>
+                    </li>
                   </ul>
                 </li>
                 <li>Add the appropriate <a def-id="track-descriptions"></a> from this <a def-id="init-segment"></a> to each of the
@@ -1453,10 +1529,13 @@ interface MediaSource : EventTarget {
               <ol>
                 <li>If the <a def-id="init-segment"></a> contains tracks with codecs the user agent does not support, then run the <a def-id="append-decode-error-algorithm"></a> and abort these steps.
                   <p class="note">User agents MAY consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not
-                    specified in the <var>type</var> parameter passed to <a def-id="addSourceBuffer"></a>. <br>
+                    specified in <var>type</var> parameter passed to
+                    (a) the most recently successful <a def-id="changeType"></a> on this <a>SourceBuffer</a> object, or
+                    (b) if no successful <a def-id="changeType"></a> has yet occurred on this object, the <a def-id="addSourceBuffer"></a> that created this <a>SourceBuffer</a> object.
                     For example, MediaSource.isTypeSupported('video/webm;codecs="vp8,vorbis"') may return true, but if
                     <a def-id="addSourceBuffer"></a> was called with 'video/webm;codecs="vp8"' and a Vorbis track appears in the
                     <a def-id="init-segment"></a>, then the user agent MAY use this step to trigger a decode error.
+                    Implementations are encouraged to trigger error in such cases only when the codec is indeed not supported.
                   </p>
                 </li>
                 <li>
@@ -1624,6 +1703,7 @@ interface MediaSource : EventTarget {
                 <li>Set <a def-id="first-init-segment-received-flag"></a> to true.</li>
               </ol>
             </li>
+            <li>Set <a def-id="pending-init-segment-for-changetype-flag"></a> to false.</li>
             <li>
               <p>If the <a def-id="ready-state"></a> attribute is <a def-id="have-nothing"></a>, then run the following steps:</p>
               <ol>
@@ -2225,8 +2305,8 @@ partial interface URL {
       <h2>Byte Stream Formats</h2>
       <p>The bytes provided through <a def-id="appendBuffer"></a> for a <a>SourceBuffer</a> form a logical byte stream. The format and
         semantics of these byte streams are defined in <dfn id="byte-stream-format-specs">byte stream format specifications</dfn>.
-        The byte stream format registry [[MSE-REGISTRY]] provides mappings between a MIME type that may be passed to <a def-id="addSourceBuffer"></a> or
-        <a def-id="isTypeSupported"></a> and the byte stream format expected by a <a>SourceBuffer</a> created with that MIME type. Implementations are encouraged to register
+        The byte stream format registry [[MSE-REGISTRY]] provides mappings between a MIME type that may be passed to <a def-id="addSourceBuffer"></a>, 
+        <a def-id="isTypeSupported"></a> or <a def-id="changeType"></a> and the byte stream format expected by a <a>SourceBuffer</a> using that MIME type for parsing newly appended data. Implementations are encouraged to register
         mappings for byte stream formats they support to facilitate interoperability. The byte stream format registry [[MSE-REGISTRY]] is the authoritative source for these
         mappings. If an implementation claims to support a MIME type listed in the registry, its <a>SourceBuffer</a> implementation MUST conform to the
         <a def-id="byte-stream-format-spec"></a> listed in the registry entry.</p>
@@ -2252,8 +2332,8 @@ partial interface URL {
             </li>
             <li><a def-id="track-ids"></a> are not the same across <a def-id="init-segments"></a>, for segments describing multiple tracks of a single type (e.g., 2 audio tracks).</li>
             <li>
-              <p>Codecs changes across <a def-id="init-segments"></a>.</p>
-              <p class="note">For example, a byte stream that starts with an <a def-id="init-segment"></a> that specifies a single AAC track and later contains an <a def-id="init-segment"></a> that specifies a single AMR-WB track is not allowed. Support for multiple codecs is handled with multiple <a>SourceBuffer</a> objects.</p>
+              <p>Unsupported codec changes occur across <a def-id="init-segments"></a>.</p>
+              <p class="note">See the <a def-id="init-segment-received-algorithm"></a>, <a def-id="addSourceBuffer"></a> and <a def-id="changeType"></a> for details and examples of codec changes.</p>
             </li>
           </ol>
         </li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1514,6 +1514,10 @@ interface MediaSource : EventTarget {
                         then the user agent MAY use this step to trigger a decode error even if the other two properties'
                         checks, above, pass. Implementations are encouraged to trigger error in such cases only when the codec
                         is indeed not supported or the other two properties' checks fail.
+                        Web authors are encouraged to use <a def-id="changeType"></a>, <a def-id="addSourceBuffer"></a> and
+                        <a def-id="isTypeSupported"></a> with precise codec parameters to more proactively detect user agent
+                        support. <a def-id="changeType"></a> is required if the <a>SourceBuffer</a> object's bytestream format
+                        is changing.
                       </p>
                     </li>
                   </ul>
@@ -1536,6 +1540,10 @@ interface MediaSource : EventTarget {
                     <a def-id="addSourceBuffer"></a> was called with 'video/webm;codecs="vp8"' and a Vorbis track appears in the
                     <a def-id="init-segment"></a>, then the user agent MAY use this step to trigger a decode error.
                     Implementations are encouraged to trigger error in such cases only when the codec is indeed not supported.
+                    Web authors are encouraged to use <a def-id="changeType"></a>, <a def-id="addSourceBuffer"></a> and
+                    <a def-id="isTypeSupported"></a> with precise codec parameters to more proactively detect user agent
+                    support. <a def-id="changeType"></a> is required if the <a>SourceBuffer</a> object's bytestream format
+                    is changing.
                   </p>
                 </li>
                 <li>

--- a/media-source.js
+++ b/media-source.js
@@ -147,6 +147,7 @@
 
     'appendBuffer': { func: idlref_helper, fragment: 'dom-sourcebuffer-appendbuffer', link_text: 'appendBuffer()',  },
     'abort': { func: idlref_helper, fragment: 'dom-sourcebuffer-abort', link_text: 'abort()',  },
+    'changeType': {func: idlref_helper, fragment: 'dom-sourcebuffer-changetype', link_text: 'changeType()',  },
     'remove': { func: idlref_helper, fragment: 'dom-sourcebuffer-remove', link_text: 'remove()',  },
     'updating': { func: idlref_helper, fragment: 'dom-sourcebuffer-updating', link_text: 'updating',  },
     'sourcebuffer-audioTracks': { func: idlref_helper, fragment: 'dom-sourcebuffer-audiotracks', link_text: 'audioTracks',  },
@@ -239,6 +240,7 @@
     'generate-timestamps-flag': { func: var_helper, fragment: '#sourcebuffer-generate-timestamps-flag', link_text: 'generate timestamps flag', },
     'MediaSource-object-URL': { func: link_helper, fragment: '#mediasource-object-url', link_text: 'MediaSource object URL', },
     'first-init-segment-received-flag': { func: var_helper, fragment: '#first-init-segment-received-flag', link_text: 'first initialization segment received flag', },
+    'pending-init-segment-for-changetype-flag': { func: var_helper, fragment: '#pending-init-segment-for-changetype-flag', link_text: 'pending initialization segment for changeType flag', },
 
     'track-buffer': { func: term_helper, fragment: 'track-buffer', link_text: 'track buffer', },
     'track-buffers': { func: term_helper, fragment: 'track-buffer', link_text: 'track buffers', },


### PR DESCRIPTION
* Includes codec-switching mention in title and abstract.
* Adds changeType() method and algorithm.
* Updates segment parser loop to disallow a media segment immediately
  following changeType() (without intervening initialization segment).
* Updates initialization segment received algorithm to allow for codec
  changes.
* Updates Byte Stream Formats section's text around codec changes.
* Updates media-source.js to include linkages for new definitions.
* Includes a regenerated index.html.